### PR TITLE
Fix systemd unit for matsci_yamz to sync with production and harden startup

### DIFF
--- a/matsci_yamz.service
+++ b/matsci_yamz.service
@@ -1,20 +1,24 @@
 # this file gets installed in /etc/systemd/system/
-# to register, sudo systemctl enable yamz_dev
-# filename yamz_dev     XXX or yamz_prd
+# to register, sudo systemctl enable matsci_yamz
 # see also /etc/nginx/sites-available/yamz
 # assume there's a group www-data, don't assume there's a group yamz
 
 [Unit]
 Description=MatSci YAMZ Service
-After=network.target multi-user.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
-Environment=""
+Environment=
+#Environment="PATH=/usr/local/bin:/usr/bin:/bin"
+#Environment="HOME=/home/matsci_yamz"
 WorkingDirectory=/home/matsci_yamz/code
 User=matsci_yamz
 Group=www-data
-ExecStart=/bin/bash -c 'pnpm start'
+#ExecStart=/usr/bin/pnpm start
+ExecStart=/bin/bash -c 'exec pnpm start'
 Restart=always
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- Reconciles `matsci_yamz.service` with the version already deployed and running on id.cci.drexel.edu (it had drifted from this checkout)
- Waits for `network-online.target` instead of `network.target` so the app doesn't start before DNS/OAuth endpoints are reachable
- Uses `exec pnpm start` so systemd can signal the actual server process directly on shutdown
- Adds `RestartSec=5` to avoid rapid restart loops on failure

## Test plan
- [x] Verified the equivalent config is already running successfully on id.cci.drexel.edu
- [ ] Confirm `systemctl daemon-reload && systemctl restart matsci_yamz.service` picks up the change cleanly in production