### PR TITLE
Switch Ollama model to gemma4:26b

### DIFF
--- a/lib/apis/ollama.ts
+++ b/lib/apis/ollama.ts
@@ -13,7 +13,7 @@ const DefinitionOutput = z.object({
 
 export const LLMSystemPrompt = process.env.SYSTEM_PROMPT!
 
-export const OllamaModel = "gemma3"
+export const OllamaModel = "gemma4:26b"
 
 export const ollama = new Ollama({
   host: process.env.OLLAMA_HOST


### PR DESCRIPTION
ws10's Ollama was converted to a systemd service on 2026-07-14 and now serves `gemma3:27b` and `gemma4:26b` only — there are no bare/`:latest` aliases, so the current `gemma3` tag fails with "model not found". This switches the app to the exact `gemma4:26b` tag (verified against `/api/tags` and `/api/show` on ws10).

One-line change, cherry-picked onto `main` so it deploys without pulling in the pending `dev` workspace changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)