### PR TITLE
Fix initial Superego deployment

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -40,10 +40,17 @@ jobs:
 
           app_root=/opt/matsci-sam
           release="${app_root}/releases/${RELEASE_SHA}"
-          previous=$(readlink -f "${app_root}/current" 2>/dev/null || true)
+          current="${app_root}/current"
+          previous=
 
-          if [[ -n "${previous}" && "${previous}" != "${app_root}/releases/"* ]]; then
-            echo "Refusing unexpected current target: ${previous}" >&2
+          if [[ -L "${current}" ]]; then
+            previous=$(readlink -f "${current}" 2>/dev/null || true)
+            if [[ -z "${previous}" || "${previous}" != "${app_root}/releases/"* || ! -d "${previous}" ]]; then
+              echo "Refusing invalid current symlink: ${current} -> ${previous:-unresolved}" >&2
+              exit 1
+            fi
+          elif [[ -e "${current}" ]]; then
+            echo "Refusing non-symlink current path: ${current}" >&2
             exit 1
           fi
 
@@ -74,7 +81,7 @@ jobs:
 
           next_link="${app_root}/.current-${RELEASE_SHA}"
           ln -sfn "${release}" "${next_link}"
-          mv -Tf "${next_link}" "${app_root}/current"
+          mv -Tf "${next_link}" "${current}"
           sudo /usr/bin/systemctl restart matsci-sam.service
 
           healthy=false
@@ -92,7 +99,7 @@ jobs:
             if [[ -n "${previous}" ]]; then
               rollback_link="${app_root}/.rollback-${RELEASE_SHA}"
               ln -sfn "${previous}" "${rollback_link}"
-              mv -Tf "${rollback_link}" "${app_root}/current"
+              mv -Tf "${rollback_link}" "${current}"
               sudo /usr/bin/systemctl restart matsci-sam.service
             fi
             exit 1

--- a/deploy/nginx/matsci-sam-public.conf
+++ b/deploy/nginx/matsci-sam-public.conf
@@ -4,7 +4,7 @@ map $http_upgrade $connection_upgrade {
 }
 
 upstream matsci_sam_superego {
-    server 10.246.250.19:80;
+    server superego.cci.drexel.edu:80;
     keepalive 32;
 }
 

--- a/deploy/setup-public-proxy.sh
+++ b/deploy/setup-public-proxy.sh
@@ -9,7 +9,7 @@ fi
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 PUBLIC_HOST=ego.cci.drexel.edu
-UPSTREAM_HOST=10.246.250.19
+UPSTREAM_HOST=superego.cci.drexel.edu
 
 if ! timeout 5 bash -c "</dev/tcp/${UPSTREAM_HOST}/80" >/dev/null 2>&1; then
   echo "Superego is not reachable at ${UPSTREAM_HOST}:80." >&2


### PR DESCRIPTION
## What changed

- distinguish a missing first-release `current` path from an existing release symlink
- continue rejecting dangling symlinks and unexpected non-symlink paths
- use the internal Superego hostname instead of publishing its private IP

## Why

The first Superego deployment failed before building because `readlink -f` normalized the missing `current` path and the safety check treated it as an unexpected deployment target.

## Validation

- simulated missing, valid, dangling, and non-symlink `current` states
- checked workflow formatting and whitespace
- verified Ego resolves and reaches `superego.cci.drexel.edu`
- scanned the changed public files for internal-note markers and the private IP
