### PR TITLE
Migrate database before deployment build

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -75,8 +75,8 @@ jobs:
 
           cd "${release}"
           pnpm install --frozen-lockfile
-          pnpm build
           pnpm db:migrate
+          pnpm build
           BUILD_RELEASE
 
           next_link="${app_root}/.current-${RELEASE_SHA}"


### PR DESCRIPTION
## What changed

Run Drizzle migrations before the Next.js production build in the Superego deployment workflow.

## Root cause

The fresh Superego database had no `tags` table. Next.js prerendered `/tags` during `pnpm build`, queried that table, and failed before the workflow reached its migration step.

## Impact

New deployments initialize the database before any build-time page queries. Existing deployments remain safe because `drizzle-kit migrate` applies only unapplied migrations.

## Validation

- `pnpm db:check`
- Prettier workflow check
- Git whitespace check
