### PR TITLE
Add gated development login

### DIFF
--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -4,6 +4,7 @@ import { getSession } from "@/lib/session";
 import { google } from "googleapis";
 import { redirect } from "next/navigation";
 import { NextRequest } from "next/server";
+import { eq, sql } from "drizzle-orm";
 
 export const GET = async (req: NextRequest) => {
   // Get session
@@ -25,15 +26,37 @@ export const GET = async (req: NextRequest) => {
   if (!userId || !email)
     throw new Error("Didn't get sufficient user info from Google!");
 
-  // Upsert the user in the database (Insert if doesn't exist and return the row)
-  const [user] = await db
-    .insert(usersTable)
-    .values({ googleId: userId, name: name || "", email })
-    .onConflictDoUpdate({
-      target: usersTable.googleId,
-      set: { googleId: userId },
-    })
-    .returning();
+  const normalizedEmail = email.trim().toLowerCase();
+  let user = await db.query.usersTable.findFirst({
+    where: eq(usersTable.googleId, userId),
+  });
+
+  // A development identity is created with the same email but without a
+  // Google ID. Attach OAuth to that row so its existing authorship survives
+  // the transition to production authentication.
+  if (!user) {
+    user = await db.query.usersTable.findFirst({
+      where: sql`lower(${usersTable.email}) = ${normalizedEmail}`,
+    });
+  }
+
+  if (user?.googleId && user.googleId !== userId)
+    throw new Error("That email is already associated with another Google account");
+
+  if (user) {
+    const [updated] = await db
+      .update(usersTable)
+      .set({ googleId: userId, name: name || user.name, email: normalizedEmail })
+      .where(eq(usersTable.id, user.id))
+      .returning();
+    user = updated;
+  } else {
+    const [inserted] = await db
+      .insert(usersTable)
+      .values({ googleId: userId, name: name || "", email: normalizedEmail })
+      .returning();
+    user = inserted;
+  }
 
   // Save id in session for future requests
   session.id = user!.id;

--- a/app/api/auth/dev-login/route.ts
+++ b/app/api/auth/dev-login/route.ts
@@ -1,31 +1,66 @@
+import { createHash, timingSafeEqual } from "node:crypto"
 import { db, usersTable } from "@yamz/db"
+import { getDevAuthUsers, isDevAuthEnabled } from "@/lib/dev-auth"
 import { getSession } from "@/lib/session"
-import { eq } from "drizzle-orm"
-import { redirect } from "next/navigation"
+import { eq, sql } from "drizzle-orm"
+import { NextRequest, NextResponse } from "next/server"
 
-const DEV_EMAIL = "dev@localhost"
+const sameSecret = (submitted: string, expected: string) => {
+  const submittedDigest = createHash("sha256").update(submitted).digest()
+  const expectedDigest = createHash("sha256").update(expected).digest()
+  return timingSafeEqual(submittedDigest, expectedDigest)
+}
 
-// Local-testing login that skips Google OAuth. Only exists in development —
-// production builds return 404.
-export const GET = async () => {
-  if (process.env.NODE_ENV === "production")
-    return new Response("Not found", { status: 404 })
+const loginRedirect = (request: NextRequest, error: string) =>
+  NextResponse.redirect(new URL(`/dev-login?error=${error}`, request.url), 303)
+
+export const POST = async (request: NextRequest) => {
+  if (!isDevAuthEnabled()) return new Response("Not found", { status: 404 })
+
+  const expectedPassword = process.env.DEV_AUTH_PASSWORD
+  if (!expectedPassword) return loginRedirect(request, "configuration")
+
+  let users
+  try {
+    users = getDevAuthUsers()
+  } catch {
+    return loginRedirect(request, "configuration")
+  }
+
+  const form = await request.formData()
+  const username = String(form.get("username") ?? "").trim().toLowerCase()
+  const password = String(form.get("password") ?? "")
+  const configuredUser = users.find((candidate) => candidate.username === username)
+
+  if (!configuredUser || !sameSecret(password, expectedPassword))
+    return loginRedirect(request, "invalid")
 
   let user = await db.query.usersTable.findFirst({
-    where: eq(usersTable.email, DEV_EMAIL)
+    where: sql`lower(${usersTable.email}) = ${configuredUser.email}`
   })
 
   if (!user) {
     const [inserted] = await db
       .insert(usersTable)
-      .values({ name: "Dev User", email: DEV_EMAIL, role: "admin" })
+      .values({
+        name: configuredUser.name,
+        email: configuredUser.email,
+        role: "user"
+      })
       .returning()
     user = inserted
+  } else if (!user.name) {
+    const [updated] = await db
+      .update(usersTable)
+      .set({ name: configuredUser.name })
+      .where(eq(usersTable.id, user.id))
+      .returning()
+    user = updated
   }
 
   const session = await getSession()
   session.id = user!.id
   await session.save()
 
-  redirect("/profile")
+  return NextResponse.redirect(new URL("/profile", request.url), 303)
 }

--- a/app/api/login/route.ts
+++ b/app/api/login/route.ts
@@ -1,7 +1,10 @@
-import { OAuthURL } from "@/lib/apis/google"
+import { isDevAuthEnabled } from "@/lib/dev-auth"
 import { NextResponse } from "next/server"
 
+export const GET = async (request: Request) => {
+  if (isDevAuthEnabled())
+    return NextResponse.redirect(new URL("/dev-login", request.url))
 
-export const GET = async () => {
+  const { OAuthURL } = await import("@/lib/apis/google")
   return NextResponse.redirect(OAuthURL)
 }

--- a/app/dev-login/page.tsx
+++ b/app/dev-login/page.tsx
@@ -1,0 +1,100 @@
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle
+} from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  getDevAuthUsers,
+  isDevAuthEnabled,
+  type DevAuthUser
+} from "@/lib/dev-auth"
+import { getSession } from "@/lib/session"
+import { notFound, redirect } from "next/navigation"
+
+type Props = {
+  searchParams: Promise<{ error?: string }>
+}
+
+export default async function DevLoginPage({ searchParams }: Props) {
+  if (!isDevAuthEnabled()) notFound()
+
+  const session = await getSession()
+  if (session.id) redirect("/profile")
+
+  let users: DevAuthUser[]
+  try {
+    users = getDevAuthUsers()
+  } catch {
+    users = []
+  }
+
+  const { error } = await searchParams
+  const errorMessage = error === "invalid"
+    ? "The selected user or shared password was not recognized."
+    : error === "configuration" || users.length === 0
+      ? "Development login has not been configured on this server."
+      : null
+
+  return (
+    <main className="px-4 py-12">
+      <Card className="mx-auto max-w-md">
+        <CardHeader>
+          <CardTitle className="font-serif text-2xl">Development login</CardTitle>
+          <CardDescription>
+            Choose your identity and enter the shared development password.
+            Your contributions will be attributed to the selected account.
+          </CardDescription>
+        </CardHeader>
+        <form action="/api/auth/dev-login" method="post">
+          <CardContent className="space-y-4">
+            {errorMessage ? (
+              <p className="text-sm text-destructive" role="alert">
+                {errorMessage}
+              </p>
+            ) : null}
+            <div className="space-y-2">
+              <Label htmlFor="username">User</Label>
+              <select
+                id="username"
+                name="username"
+                required
+                disabled={users.length === 0}
+                defaultValue=""
+                className="border-input bg-background focus-visible:border-ring focus-visible:ring-ring/50 h-9 w-full rounded-md border px-3 text-sm outline-none focus-visible:ring-[3px] disabled:opacity-50"
+              >
+                <option value="" disabled>Select your name</option>
+                {users.map((user) => (
+                  <option value={user.username} key={user.username}>
+                    {user.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="password">Shared password</Label>
+              <Input
+                id="password"
+                name="password"
+                type="password"
+                autoComplete="current-password"
+                required
+                disabled={users.length === 0}
+              />
+            </div>
+          </CardContent>
+          <CardFooter className="pt-6">
+            <Button type="submit" className="w-full" disabled={users.length === 0}>
+              Log in
+            </Button>
+          </CardFooter>
+        </form>
+      </Card>
+    </main>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,6 @@ import { SearchSection } from "./search-section"
 import { SITE_NAME } from "@/lib/site"
 import { HydrateClient, trpc } from "@/trpc/server"
 import Link from "next/link"
-import { OAuthURL } from "@/lib/apis/google"
 import { Icon } from "@iconify/react"
 import { db, definitionsTable, termsTable } from "@yamz/db"
 import { desc, eq, sql } from "drizzle-orm"
@@ -81,7 +80,7 @@ export default async function Home() {
                     </Button>
                   ) : (
                     <Button asChild>
-                      <Link href={OAuthURL}>Login</Link>
+                      <Link href="/api/login">Login</Link>
                     </Button>
                   )}
                 </div>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -4,7 +4,6 @@ import { ThemeToggle } from "./theme-provider";
 import { getSession } from "@/lib/session";
 import { db, usersTable } from "@yamz/db";
 import { eq } from "drizzle-orm";
-import { OAuthURL } from "@/lib/apis/google";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -89,7 +88,7 @@ const AuthSection = async () => {
   }
 
   return (
-    <Link href={OAuthURL}>
+    <Link href="/api/login">
       <Button variant="outline">Login</Button>
     </Link>
   );

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,12 +1,11 @@
 import { redirect } from "next/navigation"
 import { getSession } from "./session"
-import { OAuthURL } from "./apis/google"
 import { db, usersTable } from "@yamz/db"
 import { eq } from "drizzle-orm"
 
 export const auth = async () => {
   const sesh = await getSession()
-  if (!sesh.id) redirect(OAuthURL)
+  if (!sesh.id) redirect("/api/login")
 
   const user = await db.query.usersTable.findFirst({
     where: eq(usersTable.id, sesh.id)

--- a/lib/dev-auth.ts
+++ b/lib/dev-auth.ts
@@ -1,0 +1,55 @@
+import "server-only"
+
+export type DevAuthUser = {
+  username: string
+  name: string
+  email: string
+}
+
+const USERNAME_PATTERN = /^[a-z0-9][a-z0-9._-]{0,63}$/
+
+export const isDevAuthEnabled = () =>
+  process.env.DEV_AUTH_ENABLED === "true"
+
+export const getDevAuthUsers = (): DevAuthUser[] => {
+  if (!isDevAuthEnabled()) return []
+
+  const raw = process.env.DEV_AUTH_USERS
+  if (!raw) throw new Error("DEV_AUTH_USERS is required when development authentication is enabled")
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    throw new Error("DEV_AUTH_USERS must be valid JSON")
+  }
+
+  if (!Array.isArray(parsed) || parsed.length === 0)
+    throw new Error("DEV_AUTH_USERS must contain at least one user")
+
+  const usernames = new Set<string>()
+  const emails = new Set<string>()
+
+  return parsed.map((entry, index) => {
+    if (!entry || typeof entry !== "object")
+      throw new Error(`DEV_AUTH_USERS entry ${index + 1} is invalid`)
+
+    const candidate = entry as Record<string, unknown>
+    const username = typeof candidate.username === "string"
+      ? candidate.username.trim().toLowerCase()
+      : ""
+    const name = typeof candidate.name === "string" ? candidate.name.trim() : ""
+    const email = typeof candidate.email === "string"
+      ? candidate.email.trim().toLowerCase()
+      : ""
+
+    if (!USERNAME_PATTERN.test(username) || !name || !email.includes("@"))
+      throw new Error(`DEV_AUTH_USERS entry ${index + 1} is invalid`)
+    if (usernames.has(username) || emails.has(email))
+      throw new Error("DEV_AUTH_USERS usernames and emails must be unique")
+
+    usernames.add(username)
+    emails.add(email)
+    return { username, name, email }
+  })
+}

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -2,8 +2,19 @@ import { getIronSession } from "iron-session";
 import { cookies } from "next/headers";
 import { YAMZSession } from "./types";
 
-export const getSession = async () =>
-  await getIronSession<YAMZSession>(await cookies(), {
+export const getSession = async () => {
+  const allowInsecureDevCookie =
+    process.env.DEV_AUTH_ENABLED === "true" &&
+    process.env.SESSION_COOKIE_SECURE === "false"
+
+  return await getIronSession<YAMZSession>(await cookies(), {
     password: process.env.SESSION_PASSWORD!,
     cookieName: "matsci-sam-session",
-  });
+    cookieOptions: {
+      secure: !allowInsecureDevCookie,
+      sameSite: "lax",
+      httpOnly: true,
+      path: "/",
+    },
+  })
+}


### PR DESCRIPTION
## Summary

- add an explicitly gated development login screen with individually attributed users
- route unauthenticated actions through the environment-appropriate login flow
- preserve user identity when a matching Google account is connected later
- keep secure cookies as the default while allowing an explicit HTTP development override

## Why

The development deployment needs a small, controlled group to test authenticated workflows before its Google OAuth callback is available over HTTPS.

## Validation

- `pnpm check-types`
- local end-to-end login, redirect, session, and authenticated profile check
- production compilation succeeded; complete local prerender remains dependent on the workstation database configuration
