### PR TITLE
Use proxy-safe login redirects

### DIFF
--- a/app/api/auth/dev-login/route.ts
+++ b/app/api/auth/dev-login/route.ts
@@ -3,7 +3,7 @@ import { db, usersTable } from "@yamz/db"
 import { getDevAuthUsers, isDevAuthEnabled } from "@/lib/dev-auth"
 import { getSession } from "@/lib/session"
 import { eq, sql } from "drizzle-orm"
-import { NextRequest, NextResponse } from "next/server"
+import { NextRequest } from "next/server"
 
 const sameSecret = (submitted: string, expected: string) => {
   const submittedDigest = createHash("sha256").update(submitted).digest()
@@ -11,20 +11,23 @@ const sameSecret = (submitted: string, expected: string) => {
   return timingSafeEqual(submittedDigest, expectedDigest)
 }
 
-const loginRedirect = (request: NextRequest, error: string) =>
-  NextResponse.redirect(new URL(`/dev-login?error=${error}`, request.url), 303)
+const loginRedirect = (error: string) =>
+  new Response(null, {
+    status: 303,
+    headers: { Location: `/dev-login?error=${error}` }
+  })
 
 export const POST = async (request: NextRequest) => {
   if (!isDevAuthEnabled()) return new Response("Not found", { status: 404 })
 
   const expectedPassword = process.env.DEV_AUTH_PASSWORD
-  if (!expectedPassword) return loginRedirect(request, "configuration")
+  if (!expectedPassword) return loginRedirect("configuration")
 
   let users
   try {
     users = getDevAuthUsers()
   } catch {
-    return loginRedirect(request, "configuration")
+    return loginRedirect("configuration")
   }
 
   const form = await request.formData()
@@ -33,7 +36,7 @@ export const POST = async (request: NextRequest) => {
   const configuredUser = users.find((candidate) => candidate.username === username)
 
   if (!configuredUser || !sameSecret(password, expectedPassword))
-    return loginRedirect(request, "invalid")
+    return loginRedirect("invalid")
 
   let user = await db.query.usersTable.findFirst({
     where: sql`lower(${usersTable.email}) = ${configuredUser.email}`
@@ -62,5 +65,8 @@ export const POST = async (request: NextRequest) => {
   session.id = user!.id
   await session.save()
 
-  return NextResponse.redirect(new URL("/profile", request.url), 303)
+  return new Response(null, {
+    status: 303,
+    headers: { Location: "/profile" }
+  })
 }

--- a/app/api/login/route.ts
+++ b/app/api/login/route.ts
@@ -1,9 +1,12 @@
 import { isDevAuthEnabled } from "@/lib/dev-auth"
 import { NextResponse } from "next/server"
 
-export const GET = async (request: Request) => {
+export const GET = async () => {
   if (isDevAuthEnabled())
-    return NextResponse.redirect(new URL("/dev-login", request.url))
+    return new Response(null, {
+      status: 307,
+      headers: { Location: "/dev-login" }
+    })
 
   const { OAuthURL } = await import("@/lib/apis/google")
   return NextResponse.redirect(OAuthURL)


### PR DESCRIPTION
## Summary

- return relative development-login redirects from the login gateway
- return relative success and error redirects from the development-login handler

## Why

Absolute redirects were built from the application server's internal request URL and could point browsers at the reverse proxy's upstream address.

## Validation

- `pnpm check-types`
- verified the issue through the deployed reverse proxy
