### PR TITLE
Harden Superego Google authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,14 @@ DATABASE_URL=""
 GOOGLE_CLIENT_ID=""
 GOOGLE_CLIENT_SECRET=""
 GOOGLE_CALLBACK_URL=""
+GOOGLE_AUTH_ACCESS_MODE="existing-or-allowlisted"
+GOOGLE_AUTH_ALLOWED_EMAILS=""
 SESSION_PASSWORD=""
+SESSION_COOKIE_SECURE=true
+# Temporary local/development login; keep disabled when Google OAuth is active.
+DEV_AUTH_ENABLED=false
+# DEV_AUTH_USERS=""
+# DEV_AUTH_PASSWORD=""
 OLLAMA_HOST=""
 # Optional: enables the Wolfram AgentOne integration (see /admin/integrations)
 # WOLFRAM_API_KEY=""
@@ -10,4 +17,3 @@ OLLAMA_HOST=""
 SYSTEM_PROMPT_KEY="materials-reference"
 # ...or set the prompt text directly (takes precedence over SYSTEM_PROMPT_KEY)
 # SYSTEM_PROMPT=""
-

--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -1,53 +1,104 @@
-import { db, usersTable } from "@yamz/db";
-import { oauth } from "@/lib/apis/google";
-import { getSession } from "@/lib/session";
-import { google } from "googleapis";
-import { redirect } from "next/navigation";
-import { NextRequest } from "next/server";
-import { eq, sql } from "drizzle-orm";
+import { timingSafeEqual } from "node:crypto"
+import { db, usersTable } from "@yamz/db"
+import {
+  createGoogleOAuthClient,
+  getGoogleAuthAccessMode,
+  getGoogleAuthAllowedEmails,
+  getGoogleClientId
+} from "@/lib/apis/google"
+import { getSession } from "@/lib/session"
+import { redirect } from "next/navigation"
+import { NextRequest } from "next/server"
+import { eq, sql } from "drizzle-orm"
+
+const stateMatches = (submitted: string, expected: string) => {
+  const submittedBuffer = Buffer.from(submitted)
+  const expectedBuffer = Buffer.from(expected)
+  return (
+    submittedBuffer.length === expectedBuffer.length &&
+    timingSafeEqual(submittedBuffer, expectedBuffer)
+  )
+}
 
 export const GET = async (req: NextRequest) => {
-  // Get session
-  const session = await getSession();
+  const session = await getSession()
+  const submittedState = req.nextUrl.searchParams.get("state")
+  const expectedState = session.googleOAuthState
 
-  // Get the OAuth code from url params
-  const code = req.nextUrl.searchParams.get("code");
-  if (!code) redirect("/");
+  delete session.googleOAuthState
+  await session.save()
 
-  // Get google token from oauth code
-  const token = await oauth.getToken(code);
-  oauth.setCredentials(token.tokens);
+  if (
+    !submittedState ||
+    !expectedState ||
+    !stateMatches(submittedState, expectedState)
+  )
+    return new Response("Invalid Google authentication state.", { status: 400 })
 
-  // Get user info with oauth credentials
-  const userInfo = await google
-    .oauth2({ version: "v2", auth: oauth })
-    .userinfo.get();
+  if (req.nextUrl.searchParams.has("error"))
+    return new Response("Google sign-in was not completed.", { status: 400 })
+
+  const code = req.nextUrl.searchParams.get("code")
+  if (!code)
+    return new Response("Google did not return an authorization code.", {
+      status: 400
+    })
+
+  const oauth = createGoogleOAuthClient()
+  const token = await oauth.getToken(code)
+  const idToken = token.tokens.id_token
+  if (!idToken)
+    return new Response("Google did not return an identity token.", {
+      status: 400
+    })
+
+  const ticket = await oauth.verifyIdToken({
+    idToken,
+    audience: getGoogleClientId()
+  })
+  const userInfo = ticket.getPayload()
+  if (!userInfo)
+    return new Response("Google identity verification failed.", { status: 403 })
+
   const {
-    id: userId,
+    sub: userId,
     name,
     email,
     given_name: givenName,
     family_name: familyName,
-  } = userInfo.data;
-  if (!userId || !email)
-    throw new Error("Didn't get sufficient user info from Google!");
+    email_verified: emailVerified
+  } = userInfo
+  if (!userId || !email || !emailVerified)
+    return new Response("Google did not return a verified email address.", {
+      status: 403
+    })
 
-  const normalizedEmail = email.trim().toLowerCase();
+  const normalizedEmail = email.trim().toLowerCase()
   let user = await db.query.usersTable.findFirst({
-    where: eq(usersTable.googleId, userId),
-  });
+    where: eq(usersTable.googleId, userId)
+  })
 
   // A development identity is created with the same email but without a
   // Google ID. Attach OAuth to that row so its existing authorship survives
   // the transition to production authentication.
   if (!user) {
     user = await db.query.usersTable.findFirst({
-      where: sql`lower(${usersTable.email}) = ${normalizedEmail}`,
-    });
+      where: sql`lower(${usersTable.email}) = ${normalizedEmail}`
+    })
   }
 
+  const isNewUserAllowed =
+    getGoogleAuthAccessMode() === "open" ||
+    getGoogleAuthAllowedEmails().has(normalizedEmail)
+  if (!user && !isNewUserAllowed)
+    return new Response("This Google account is not authorized.", {
+      status: 403
+    })
+
   if (user?.googleId && user.googleId !== userId)
-    throw new Error("That email is already associated with another Google account");
+    throw new Error(
+      "That email is already associated with another Google account"
+    )
 
   if (user) {
     const [updated] = await db
@@ -57,11 +108,11 @@ export const GET = async (req: NextRequest) => {
         name: name || user.name,
         email: normalizedEmail,
         firstName: user.firstName || givenName || null,
-        lastName: user.lastName || familyName || null,
+        lastName: user.lastName || familyName || null
       })
       .where(eq(usersTable.id, user.id))
-      .returning();
-    user = updated;
+      .returning()
+    user = updated
   } else {
     const [inserted] = await db
       .insert(usersTable)
@@ -70,16 +121,14 @@ export const GET = async (req: NextRequest) => {
         name: name || "",
         email: normalizedEmail,
         firstName: givenName || null,
-        lastName: familyName || null,
+        lastName: familyName || null
       })
-      .returning();
-    user = inserted;
+      .returning()
+    user = inserted
   }
 
-  // Save id in session for future requests
-  session.id = user!.id;
-  await session.save();
+  session.id = user!.id
+  await session.save()
 
-  // Redirect to profile page
-  redirect("/profile");
-};
+  redirect("/profile")
+}

--- a/app/api/auth/google/route.ts
+++ b/app/api/auth/google/route.ts
@@ -1,0 +1,14 @@
+import { randomBytes } from "node:crypto"
+import { createGoogleAuthorizationUrl } from "@/lib/apis/google"
+import { getSession } from "@/lib/session"
+import { NextResponse } from "next/server"
+
+export const GET = async () => {
+  const session = await getSession()
+  const state = randomBytes(32).toString("hex")
+
+  session.googleOAuthState = state
+  await session.save()
+
+  return NextResponse.redirect(createGoogleAuthorizationUrl(state))
+}

--- a/app/api/login/route.ts
+++ b/app/api/login/route.ts
@@ -1,5 +1,4 @@
 import { isDevAuthEnabled } from "@/lib/dev-auth"
-import { NextResponse } from "next/server"
 
 export const GET = async () => {
   if (isDevAuthEnabled())
@@ -8,6 +7,8 @@ export const GET = async () => {
       headers: { Location: "/dev-login" }
     })
 
-  const { OAuthURL } = await import("@/lib/apis/google")
-  return NextResponse.redirect(OAuthURL)
+  return new Response(null, {
+    status: 307,
+    headers: { Location: "/api/auth/google" }
+  })
 }

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -62,17 +62,26 @@ sudo certbot --nginx --redirect -d ego.cci.drexel.edu
 sudo certbot renew --dry-run
 ```
 
-Until Ego's public ports and certificate are available, the application can be
-demonstrated over the Drexel network at `http://superego.cci.drexel.edu` with:
+Superego has its own browser-trusted certificate and can be used directly over
+the Drexel network or VPN with:
 
 ```dotenv
-NEXT_PUBLIC_SITE_URL=http://superego.cci.drexel.edu
-GOOGLE_CALLBACK_URL=http://superego.cci.drexel.edu/api/auth/callback
+NEXT_PUBLIC_SITE_URL=https://superego.cci.drexel.edu
+GOOGLE_CALLBACK_URL=https://superego.cci.drexel.edu/api/auth/callback
+SESSION_COOKIE_SECURE=true
 ```
 
-Do not enable Google authentication for this HTTP-only interim deployment.
-After Ego has a valid certificate, change both values to the HTTPS Ego URL and
-rebuild.
+Use a separate Google OAuth web client for Superego. Its exact authorized
+redirect URI is
+`https://superego.cci.drexel.edu/api/auth/callback`. Configure
+`GOOGLE_AUTH_ACCESS_MODE=existing-or-allowlisted` for a closed trial or
+`GOOGLE_AUTH_ACCESS_MODE=open` to let any verified Google account create a
+user. Existing database users can sign in in either mode; the optional
+`GOOGLE_AUTH_ALLOWED_EMAILS` setting controls which new users are invited in
+the restricted mode. During the transition, `/api/auth/google` can test Google
+sign-in while the gated development login remains enabled; disable and remove
+the temporary development-login settings only after all intended identities
+have passed.
 
 Superego accepts `ego.cci.drexel.edu`, `superego.cci.drexel.edu`, and
 `sam.cci.drexel.edu`, so the server and database layout do not change when the

--- a/deploy/app.env.example
+++ b/deploy/app.env.example
@@ -1,7 +1,5 @@
 # This URL is compiled into browser assets during `pnpm build`.
-# Use Superego over the Drexel network until Ego's public TLS is available.
-# Change this URL and rebuild when the public certificate is ready.
-NEXT_PUBLIC_SITE_URL=http://superego.cci.drexel.edu
+NEXT_PUBLIC_SITE_URL=https://superego.cci.drexel.edu
 NEXT_PUBLIC_SITE_NAME="MatSci SAM"
 
 # The matsci-sam service account maps to the same-named PostgreSQL role through
@@ -10,8 +8,22 @@ DATABASE_URL=postgresql:///matsci-sam?host=/var/run/postgresql
 
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
-GOOGLE_CALLBACK_URL=http://superego.cci.drexel.edu/api/auth/callback
+GOOGLE_CALLBACK_URL=https://superego.cci.drexel.edu/api/auth/callback
+# Use "existing-or-allowlisted" for a closed trial, or "open" to let any
+# verified Google account create a user.
+GOOGLE_AUTH_ACCESS_MODE=existing-or-allowlisted
+# Optional exact, comma-separated emails permitted to create new users in the
+# existing-or-allowlisted mode. Existing database users can always sign in.
+GOOGLE_AUTH_ALLOWED_EMAILS=
 SESSION_PASSWORD=
+SESSION_COOKIE_SECURE=true
+
+# Temporary transition login. Remove these after Google authentication has
+# been tested for every configured identity.
+DEV_AUTH_ENABLED=false
+# DEV_AUTH_USERS=
+# DEV_AUTH_PASSWORD=
+
 OLLAMA_HOST=
 SYSTEM_PROMPT_KEY=materials-reference
 

--- a/developing.md
+++ b/developing.md
@@ -632,7 +632,11 @@ Tags are many-to-many with definitions. See `trpc/routers/tags.ts` for the API a
 Ensure all required variables are set (see `.env.example`):
 
 - `DATABASE_URL` - PostgreSQL connection
-- `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_CALLBACK_URL` - OAuth
+- `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_CALLBACK_URL` - Google
+  OAuth web client
+- `GOOGLE_AUTH_ACCESS_MODE` - `existing-or-allowlisted` or `open`
+- `GOOGLE_AUTH_ALLOWED_EMAILS` - optional exact comma-separated accounts
+  allowed to create users in the restricted mode
 - `SESSION_PASSWORD` - Session encryption (32+ chars)
 - `OLLAMA_HOST` - AI service URL
 - `SYSTEM_PROMPT_KEY` - Name of an AI system prompt from `lib/prompts.json` — see [AI System Prompts](#ai-system-prompts)

--- a/lib/apis/google.ts
+++ b/lib/apis/google.ts
@@ -1,12 +1,50 @@
-import { OAuth2Client } from "google-auth-library";
+import { OAuth2Client } from "google-auth-library"
 
-export const oauth = new OAuth2Client(
-  process.env.GOOGLE_CLIENT_ID!,
-  process.env.GOOGLE_CLIENT_SECRET!,
-  process.env.GOOGLE_CALLBACK_URL!,
-);
+const requiredGoogleSetting = (name: string) => {
+  const value = process.env[name]?.trim()
+  if (!value) throw new Error(`${name} is required for Google authentication`)
+  return value
+}
 
-export const OAuthURL = oauth.generateAuthUrl({
-  scope:
-    "https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email",
-});
+export const getGoogleClientId = () => requiredGoogleSetting("GOOGLE_CLIENT_ID")
+
+export const createGoogleOAuthClient = () =>
+  new OAuth2Client(
+    getGoogleClientId(),
+    requiredGoogleSetting("GOOGLE_CLIENT_SECRET"),
+    requiredGoogleSetting("GOOGLE_CALLBACK_URL")
+  )
+
+export const createGoogleAuthorizationUrl = (state: string) =>
+  createGoogleOAuthClient().generateAuthUrl({
+    access_type: "online",
+    prompt: "select_account",
+    scope: ["openid", "email", "profile"],
+    state
+  })
+
+export const getGoogleAuthAccessMode = () => {
+  const mode = requiredGoogleSetting("GOOGLE_AUTH_ACCESS_MODE")
+  if (mode !== "existing-or-allowlisted" && mode !== "open")
+    throw new Error(
+      "GOOGLE_AUTH_ACCESS_MODE must be existing-or-allowlisted or open"
+    )
+  return mode
+}
+
+export const getGoogleAuthAllowedEmails = () => {
+  const raw = process.env.GOOGLE_AUTH_ALLOWED_EMAILS?.trim()
+  if (!raw) return new Set<string>()
+
+  const emails = raw
+    .split(",")
+    .map((email) => email.trim().toLowerCase())
+    .filter(Boolean)
+
+  if (emails.some((email) => !email.includes("@")))
+    throw new Error(
+      "GOOGLE_AUTH_ALLOWED_EMAILS must contain valid comma-separated email addresses"
+    )
+
+  return new Set(emails)
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,3 +1,4 @@
 export interface YAMZSession {
-  id?: number;
+  id?: number
+  googleOAuthState?: string
 }


### PR DESCRIPTION
## What changed

- adds a dedicated Google OAuth initiation route with one-time state handling
- validates callback state, audience, verified email, and existing Google account bindings
- supports `existing-or-allowlisted` and `open` access modes
- keeps the temporary development login available for a staged Superego cutover
- documents the protected environment settings and deployment sequence

## Why

Superego now has HTTPS and can use Google authentication while preserving the existing user records and definition attribution. The restrictive initial mode permits known contributors and explicitly allowlisted accounts before broader access is enabled.

## Validation

- `pnpm check-types`
- `pnpm db:check`
- `pnpm build`

All checks passed against commit `749b914`. The production build reports four existing, unrelated lint warnings.

## Deployment hold

Do not merge until the Google web client has been created and the protected Superego environment has the client ID and secret. A merge into `dev` automatically triggers the Superego deployment workflow.
