### PR TITLE
Provision independent Ego public runtime

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 DATABASE_URL=""
 NEXT_PUBLIC_SITE_URL="http://localhost:3000"
+NEXT_PUBLIC_SITE_NAME="MatSci SAM"
 GOOGLE_CLIENT_ID=""
 GOOGLE_CLIENT_SECRET=""
 GOOGLE_CALLBACK_URL=""
@@ -42,5 +43,6 @@ OLLAMA_HOST=""
 # WOLFRAM_API_KEY=""
 # Pick a named system prompt from lib/prompts.json (add your own there)...
 SYSTEM_PROMPT_KEY="materials-reference"
+REFINE_PROMPT_KEY="refine"
 # ...or set the prompt text directly (takes precedence over SYSTEM_PROMPT_KEY)
 # SYSTEM_PROMPT=""

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -15,12 +15,12 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 10
+          version: 10.34.5
 
       - name: Install Node
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 24.18.0
           cache: pnpm
 
       - name: Install Dependencies
@@ -46,6 +46,16 @@ jobs:
       - name: Test Interface State
         run: |
           pnpm test:interface
+
+      - name: Test Deployment Contract
+        run: |
+          pnpm test:deployment
+          bash -n \
+            deploy/bootstrap-server.sh \
+            deploy/check-runtime-parity.sh \
+            deploy/provision-ego-runtime.sh \
+            deploy/lib/provision-ego-runtime-remote.sh \
+            deploy/ops/matsci-sam-ops
 
       - name: Check Migrations
         run: |

--- a/README.md
+++ b/README.md
@@ -33,15 +33,17 @@ updates source control but does not deploy Superego.
 
 Superego deployment is a separate maintainer operation. The `dev` branch does
 not grant a self-hosted runner authority to migrate its database or restart
-its service. The files in [`deploy/`](deploy/) contain
-host-provisioning components, the reviewed in-place Superego release wrapper,
-and the one-way Superego database snapshot wrapper. Private environment
-policy remains in `docs-internal`.
+its service. The files in [`deploy/`](deploy/) contain shared host
+provisioning, the reviewed in-place Superego release wrapper, the independent
+Ego runtime profile, and the one-way Superego database snapshot wrapper.
+Private environment policy remains in `docs-internal`.
 
-Do not merge or push any commit to `main`. Its active legacy production
-workflow can migrate and restart the legacy public environment. Retire or
-disable that workflow through a separately reviewed production change first,
-then verify the new boundary before using `main`.
+The legacy production workflows are disabled. Do not merge or push a public
+candidate to `main` until their self-hosted runners and deployment privileges
+have also been retired and the old deployment workflow has been removed.
+After that boundary is verified, the intended public path promotes a tree
+already validated on Superego from `dev` to `main` and builds it independently
+on Ego.
 
 ## Project structure
 

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,28 @@
+import { sql } from "drizzle-orm"
+
+import { db } from "@/drizzle/connection"
+
+export const dynamic = "force-dynamic"
+
+const headers = {
+  "Cache-Control": "no-store",
+  "Content-Type": "application/json"
+}
+
+export async function GET() {
+  try {
+    await db.execute(sql`
+      select
+        (select count(*) from "users"),
+        (select count(*) from "terms"),
+        (select count(*) from "definitions"),
+        (select count(*) from drizzle."__drizzle_migrations")
+    `)
+    return Response.json({ status: "ok" }, { headers })
+  } catch {
+    return Response.json(
+      { status: "unavailable" },
+      { status: 503, headers }
+    )
+  }
+}

--- a/contributing.md
+++ b/contributing.md
@@ -32,10 +32,13 @@ MatSci SAM uses `dev` as its integration branch.
 5. A maintainer merges the pull request into `dev`. The merge updates source
    control only. It does not deploy Superego or another server.
 
-6. A maintainer deploys a reviewed `dev` commit through the environment
-   runbook. Promotion to `main` and public deployment are separate decisions.
-   Do not merge or push any commit to `main` while its active legacy
-   production workflow can migrate and restart the public environment.
+6. A maintainer deploys a reviewed `dev` commit to Superego through the
+   environment runbook. Promotion to `main` and deployment to the independent
+   Ego public runtime are separate decisions. The legacy workflows are
+   disabled, but `main` remains blocked until their self-hosted runners and
+   deployment privileges are retired and the old deployment workflow is
+   removed. A public candidate must use the same Git tree already validated on
+   Superego.
 
 Never put credentials, database dumps, private environment files, or TLS keys
 in a branch, pull request, issue, workflow log, or build artifact.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,8 +1,8 @@
 # Deployment and host provisioning
 
-This directory contains the reviewed wrappers for Superego operations and the
-stable components needed to provision a new MatSci SAM application host.
-Private authority, runtime, and server facts remain in the internal runbooks.
+This directory contains the reviewed wrappers and host profiles for the
+Superego development runtime and the independent Ego public runtime. Private
+authority, release, and server facts remain in the internal runbooks.
 
 | Purpose | Location on a provisioned host |
 | --- | --- |
@@ -14,11 +14,22 @@ Private authority, runtime, and server facts remain in the internal runbooks.
 
 ## Files
 
-- `bootstrap-server.sh` provisions a new application host.
-- `app.env.example` lists supported runtime settings without secret values.
+- `bootstrap-server.sh` provisions a replacement private development host.
+- `runtime-versions.env` pins the shared host runtime contract.
+- `app.env.example` is the Superego configuration profile without secrets.
+- `ego/app.env.example` is the independent Ego public profile.
 - `systemd/matsci-sam.service` is the canonical service unit.
-- `nginx/matsci-sam.conf` is an HTTP bootstrap configuration. It is not the
-  complete TLS configuration installed on an existing host.
+- `nginx/matsci-sam-superego.conf` is the private development HTTP bootstrap
+  configuration. It contains no Ego proxy path and is not the complete TLS
+  configuration installed on an existing host.
+- `nginx/matsci-sam-public-maintenance.conf` is the known-good Ego maintenance
+  configuration.
+- `nginx/matsci-sam-public-local-ready.conf` is the disabled Ego candidate
+  that proxies to the local loopback application.
+- `provision-ego-runtime.sh` installs the runtime and empty local database
+  without changing public maintenance behavior.
+- `check-runtime-parity.sh` compares non-secret host versions, service
+  configuration, listener boundaries, and authority markers.
 - `deploy-superego-from-workstation.sh` publishes reviewed source while
   preserving and migrating the Superego-authoritative database.
 - `pull-superego-db-to-workstation.sh` refreshes the replaceable local
@@ -30,8 +41,9 @@ Private authority, runtime, and server facts remain in the internal runbooks.
 - Files under `lib/` are staged implementation details. Do not invoke them
   directly.
 
-Do not rerun the bootstrap script on an existing server. It installs packages
-and replaces Nginx and systemd configuration.
+Do not run `bootstrap-server.sh` on Ego. That script replaces the enabled
+Nginx site on a new host. Ego already has public TLS and a protected
+maintenance contract.
 
 ## New-host bootstrap
 
@@ -49,13 +61,61 @@ standard directories. PostgreSQL accepts local Unix-socket connections only.
 The application service remains disabled until an administrator installs the
 protected environment, TLS configuration, and first release.
 
+## Ego runtime provisioning
+
+Ego uses the same Node.js, pnpm, PostgreSQL, pgvector, service-unit, directory,
+and socket-only database contract as Superego. It has distinct configuration,
+OAuth credentials, session and token keys, database rows, releases, TLS, and
+Nginx configuration.
+
+Run the optional preflight and then the supervised provisioning command from
+the recorded control workstation on a clean `dev` checkout equal to
+`origin/dev`:
+
+```bash
+./deploy/provision-ego-runtime.sh --check-only
+./deploy/provision-ego-runtime.sh
+```
+
+The command requires the user to enter sudo on Ego. It leaves the known-good
+maintenance site active, keeps `matsci-sam.service` disabled, creates an empty
+local `matsci-sam` database with pgvector, and records the Ego data authority
+as `uninitialized`.
+
+Verify runtime parity with:
+
+```bash
+./deploy/check-runtime-parity.sh
+```
+
+Provisioning does not seed data, install OAuth credentials, deploy an
+application release, or activate the public application configuration.
+
+The later one-time seed requires a privacy review of the Superego snapshot.
+User identities, provider-bound OAuth tokens, private feedback, and
+conversation records must not become public by accident. A successful seed
+changes the Ego authority marker from `uninitialized` to `ego`. After that
+change, never replace or refresh the Ego database from Superego.
+
 ## Deployment boundary
 
 A merge to `dev` updates source control only. It does not deploy Superego.
 Consult `docs-internal/CURRENT-DEV-STATE.md` and
 `docs-internal/SUPEREGO-DEV-ACCESS.md` before an operation. Do not merge or
-push any commit to `main` while its active legacy production workflow can
-migrate or restart a public environment.
+push a public candidate to `main` until the disabled legacy production
+workflow and its self-hosted runner have been retired.
+
+The release path is:
+
+```text
+reviewed origin/dev -> Superego validation
+identical reviewed tree -> origin/main -> Ego
+```
+
+The main commit may differ from the validated dev commit when GitHub creates a
+merge commit. The application tree and migration tree must match. Ego builds
+that tree again with the public environment because
+`NEXT_PUBLIC_SITE_URL` is build-time configuration.
 
 When both authority records identify Superego as the shared-data authority,
 run this from the recorded control workstation:

--- a/deploy/bootstrap-server.sh
+++ b/deploy/bootstrap-server.sh
@@ -8,6 +8,7 @@ if [[ ${EUID} -ne 0 ]]; then
 fi
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+VERSIONS_FILE=${SCRIPT_DIR}/runtime-versions.env
 # Keep later runuser calls independent of the invoking administrator's home
 # directory permissions.
 cd /
@@ -19,8 +20,37 @@ APP_STATE=/var/lib/matsci-sam
 APP_CONFIG=/etc/matsci-sam
 DB_NAME=matsci-sam
 DB_ROLE=matsci-sam
-NODE_MAJOR=24
-POSTGRES_MAJOR=17
+POSTGRES_KEY_FINGERPRINT=B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
+NODESOURCE_KEY_FINGERPRINT=6F71F525282841EEDAF851B42F59B5F99B1BE0B4
+postgres_key=
+nodesource_key=
+
+cleanup() {
+  [[ -z ${postgres_key} || ! -e ${postgres_key} ]] ||
+    rm -f "${postgres_key}"
+  [[ -z ${nodesource_key} || ! -e ${nodesource_key} ]] ||
+    rm -f "${nodesource_key}"
+}
+trap cleanup EXIT
+
+[[ -f ${VERSIONS_FILE} && ! -L ${VERSIONS_FILE} ]] ||
+  { echo "The reviewed runtime-version contract is unavailable." >&2; exit 1; }
+while IFS= read -r line || [[ -n ${line} ]]; do
+  [[ ${line} =~ ^[[:space:]]*# || ${line} =~ ^[[:space:]]*$ ]] && continue
+  [[ ${line} =~ ^[A-Z0-9_]+=[A-Za-z0-9.+:~-]+$ ]] ||
+    { echo "Malformed runtime-version line." >&2; exit 1; }
+done <"${VERSIONS_FILE}"
+# shellcheck disable=SC1090
+source "${VERSIONS_FILE}"
+NODE_MAJOR=${NODE_VERSION#v}
+NODE_MAJOR=${NODE_MAJOR%%.*}
+[[ ${NODE_MAJOR} =~ ^[0-9]+$ ]] ||
+  { echo "The reviewed Node.js version is invalid." >&2; exit 1; }
+. /etc/os-release
+[[ ${ID} == ubuntu && ${VERSION_ID} == "${UBUNTU_VERSION}" ]] ||
+  { echo "The host does not match the reviewed Ubuntu version." >&2; exit 1; }
+[[ $(dpkg --print-architecture) == "${ARCHITECTURE}" ]] ||
+  { echo "The host does not match the reviewed architecture." >&2; exit 1; }
 
 export DEBIAN_FRONTEND=noninteractive
 
@@ -32,9 +62,8 @@ apt-get install -y \
   curl \
   git \
   gnupg \
-  nginx \
+  "nginx=${NGINX_PACKAGE_VERSION}" \
   openssl \
-  postgresql-common \
   xz-utils
 
 echo "Configuring the official PostgreSQL Apt repository..."
@@ -45,10 +74,21 @@ if [[ -z ${VERSION_CODENAME:-} ]]; then
 fi
 
 install -d -m 0755 /usr/share/postgresql-common/pgdg
+postgres_key=$(mktemp)
 curl --fail --silent --show-error \
   https://www.postgresql.org/media/keys/ACCC4CF8.asc \
-  -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc
-chmod 0644 /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc
+  -o "${postgres_key}"
+postgres_key_fingerprint=$(
+  gpg --batch --show-keys --with-colons "${postgres_key}" |
+    awk -F: '$1 == "fpr" { print $10; exit }'
+)
+[[ ${postgres_key_fingerprint} == "${POSTGRES_KEY_FINGERPRINT}" ]] ||
+  { echo "The PostgreSQL repository signing key fingerprint changed." >&2; exit 1; }
+install -o root -g root -m 0644 \
+  "${postgres_key}" \
+  /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc
+rm -f "${postgres_key}"
+postgres_key=
 
 cat >/etc/apt/sources.list.d/pgdg.sources <<EOF
 Types: deb
@@ -61,20 +101,28 @@ EOF
 
 apt-get update
 apt-get install -y \
-  "postgresql-${POSTGRES_MAJOR}" \
-  "postgresql-${POSTGRES_MAJOR}-pgvector"
+  "postgresql-common=${POSTGRES_COMMON_PACKAGE_VERSION}" \
+  "postgresql-${POSTGRES_MAJOR}=${POSTGRES_PACKAGE_VERSION}" \
+  "postgresql-${POSTGRES_MAJOR}-pgvector=${PGVECTOR_PACKAGE_VERSION}"
 
 echo "Configuring the NodeSource Node.js ${NODE_MAJOR}.x repository..."
 install -d -m 0755 /etc/apt/keyrings
 nodesource_key=$(mktemp)
-trap 'rm -f "${nodesource_key}"' EXIT
 curl -fsSL \
   https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
   -o "${nodesource_key}"
+nodesource_key_fingerprint=$(
+  gpg --batch --show-keys --with-colons "${nodesource_key}" |
+    awk -F: '$1 == "fpr" { print $10; exit }'
+)
+[[ ${nodesource_key_fingerprint} == "${NODESOURCE_KEY_FINGERPRINT}" ]] ||
+  { echo "The NodeSource repository signing key fingerprint changed." >&2; exit 1; }
 gpg --batch --yes --dearmor \
   --output /etc/apt/keyrings/nodesource.gpg \
   "${nodesource_key}"
 chmod 0644 /etc/apt/keyrings/nodesource.gpg
+rm -f "${nodesource_key}"
+nodesource_key=
 
 cat >/etc/apt/sources.list.d/nodesource.sources <<EOF
 Types: deb
@@ -86,8 +134,8 @@ Signed-By: /etc/apt/keyrings/nodesource.gpg
 EOF
 
 apt-get update
-apt-get install -y nodejs
-npm install --global pnpm@10
+apt-get install -y "nodejs=${NODE_PACKAGE_VERSION}"
+npm install --global "pnpm@${PNPM_VERSION}"
 
 echo "Creating the application service account and standard directories..."
 if ! getent group "${APP_GROUP}" >/dev/null; then
@@ -116,10 +164,14 @@ if [[ ! -e "${APP_CONFIG}/app.env" ]]; then
     "${SCRIPT_DIR}/app.env.example" \
     "${APP_CONFIG}/app.env"
   session_password=$(openssl rand -hex 32)
+  auth_encryption_key=$(openssl rand -base64 32 | tr -d '\n')
   sed -i \
     "s/^SESSION_PASSWORD=$/SESSION_PASSWORD=${session_password}/" \
     "${APP_CONFIG}/app.env"
-  unset session_password
+  sed -i \
+    "s|^AUTH_TOKEN_ENCRYPTION_KEY=$|AUTH_TOKEN_ENCRYPTION_KEY=${auth_encryption_key}|" \
+    "${APP_CONFIG}/app.env"
+  unset session_password auth_encryption_key
 fi
 
 echo "Creating the local application database and enabling pgvector..."
@@ -147,7 +199,7 @@ systemctl restart postgresql
 
 echo "Installing nginx and systemd configuration..."
 install -o root -g root -m 0644 \
-  "${SCRIPT_DIR}/nginx/matsci-sam.conf" \
+  "${SCRIPT_DIR}/nginx/matsci-sam-superego.conf" \
   /etc/nginx/sites-available/matsci-sam
 ln -sfn /etc/nginx/sites-available/matsci-sam \
   /etc/nginx/sites-enabled/matsci-sam

--- a/deploy/check-runtime-parity.sh
+++ b/deploy/check-runtime-parity.sh
@@ -1,0 +1,396 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+versions_file=${script_dir}/runtime-versions.env
+service_file=${script_dir}/systemd/matsci-sam.service
+maintenance_file=${script_dir}/nginx/matsci-sam-public-maintenance.conf
+candidate_file=${script_dir}/nginx/matsci-sam-public-local-ready.conf
+operations_file=${script_dir}/ops/matsci-sam-ops
+sudoers_file=${script_dir}/ops/matsci-sam-ops.sudoers
+allow_unprovisioned_ego=false
+failures=0
+
+usage() {
+  cat <<'USAGE'
+Usage: deploy/check-runtime-parity.sh [options]
+
+Compare the non-secret runtime contract, listeners, service unit, and authority
+markers on Superego and Ego.
+
+Options:
+  --allow-unprovisioned-ego  Report the known pre-provisioning Ego state
+  -h, --help                 Show this help
+USAGE
+}
+
+while (($#)); do
+  case $1 in
+    --allow-unprovisioned-ego)
+      allow_unprovisioned_ego=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+for command in awk curl sha256sum ssh
+do
+  command -v "${command}" >/dev/null || {
+    echo "Required command is unavailable: ${command}" >&2
+    exit 1
+  }
+done
+for file in "${versions_file}" "${service_file}" "${maintenance_file}" \
+  "${candidate_file}" "${operations_file}" "${sudoers_file}"
+do
+  [[ -f ${file} && ! -L ${file} ]] || {
+    echo "Required parity file is missing or unsafe: ${file}" >&2
+    exit 1
+  }
+done
+
+# The file is reviewed source and contains only a strict set of non-secret
+# version tokens.
+while IFS= read -r line || [[ -n ${line} ]]; do
+  [[ ${line} =~ ^[[:space:]]*# || ${line} =~ ^[[:space:]]*$ ]] && continue
+  [[ ${line} =~ ^[A-Z0-9_]+=[A-Za-z0-9.+:~-]+$ ]] || {
+    echo "Malformed runtime-version line." >&2
+    exit 1
+  }
+done <"${versions_file}"
+# shellcheck disable=SC1090
+source "${versions_file}"
+
+expected_service_sha=$(sha256sum "${service_file}" | awk '{print $1}')
+expected_maintenance_sha=$(sha256sum "${maintenance_file}" | awk '{print $1}')
+expected_candidate_sha=$(sha256sum "${candidate_file}" | awk '{print $1}')
+expected_operations_sha=$(sha256sum "${operations_file}" | awk '{print $1}')
+expected_sudoers_sha=$(sha256sum "${sudoers_file}" | awk '{print $1}')
+
+collect_remote() {
+  local alias=$1
+  ssh -o BatchMode=yes -o ConnectTimeout=8 "${alias}" \
+    /bin/bash -s -- "${POSTGRES_MAJOR}" <<'REMOTE'
+set -Eeuo pipefail
+postgres_major=$1
+package_or_absent() {
+  dpkg-query -W -f='${Version}' "$1" 2>/dev/null || echo absent
+}
+systemd_or_absent() {
+  local operation=$1
+  local unit=$2
+  local value
+  value=$(systemctl "${operation}" "${unit}" 2>/dev/null || true)
+  printf '%s\n' "${value:-absent}"
+}
+
+. /etc/os-release
+printf 'host\t%s\n' "$(hostname)"
+printf 'ubuntu\t%s\n' "${VERSION_ID}"
+printf 'architecture\t%s\n' "$(dpkg --print-architecture)"
+printf 'nginx_package\t%s\n' "$(package_or_absent nginx)"
+printf 'nginx_service\t%s\n' \
+  "$(systemd_or_absent is-active nginx.service)"
+printf 'node_package\t%s\n' "$(package_or_absent nodejs)"
+printf 'node\t%s\n' "$(node --version 2>/dev/null || echo absent)"
+printf 'pnpm\t%s\n' "$(pnpm --version 2>/dev/null || echo absent)"
+printf 'postgres_package\t%s\n' \
+  "$(package_or_absent "postgresql-${postgres_major}")"
+printf 'postgres_common_package\t%s\n' "$(package_or_absent postgresql-common)"
+printf 'pgvector_package\t%s\n' \
+  "$(package_or_absent "postgresql-${postgres_major}-pgvector")"
+printf 'postgres_service\t%s\n' \
+  "$(systemd_or_absent is-active postgresql.service)"
+printf 'application_service\t%s\n' \
+  "$(systemd_or_absent is-active matsci-sam.service)"
+printf 'application_enabled\t%s\n' \
+  "$(systemd_or_absent is-enabled matsci-sam.service)"
+printf 'service_unit_sha256\t%s\n' "$(
+  if [[ -f /etc/systemd/system/matsci-sam.service ]]; then
+    sha256sum /etc/systemd/system/matsci-sam.service | awk '{print $1}'
+  else
+    echo absent
+  fi
+)"
+printf 'release\t%s\n' \
+  "$(readlink -e /opt/matsci-sam/current 2>/dev/null || echo absent)"
+printf 'data_authority\t%s\n' "$(
+  case $(hostname) in
+    cci-superego)
+      marker=/home/cr625/superego-admin/DATA-AUTHORITY
+      ;;
+    cci-ego)
+      marker=/home/cr625/ego-admin/DATA-AUTHORITY
+      ;;
+    *)
+      marker=
+      ;;
+  esac
+  if [[ -n ${marker} && -f ${marker} ]]; then
+    sed -n '1p' "${marker}"
+  else
+    echo absent
+  fi
+)"
+printf 'postgres_tcp\t%s\n' "$(
+  if ss -ltnH '( sport = :5432 )' | grep -q .; then
+    echo listening
+  else
+    echo closed
+  fi
+)"
+printf 'application_listener\t%s\n' "$(
+  listeners=$(ss -ltnH '( sport = :3000 )' | awk '{print $4}' | paste -sd,)
+  printf '%s' "${listeners:-closed}"
+)"
+printf 'maintenance_sha256\t%s\n' "$(
+  if [[ -f /etc/nginx/sites-available/matsci-sam-public ]]; then
+    sha256sum /etc/nginx/sites-available/matsci-sam-public | awk '{print $1}'
+  else
+    echo absent
+  fi
+)"
+printf 'local_candidate_sha256\t%s\n' "$(
+  if [[ -f /etc/nginx/sites-available/matsci-sam-public-local-ready ]]; then
+    sha256sum /etc/nginx/sites-available/matsci-sam-public-local-ready |
+      awk '{print $1}'
+  else
+    echo absent
+  fi
+)"
+printf 'active_site_target\t%s\n' "$(
+  if [[ -L /etc/nginx/sites-enabled/matsci-sam-public ]]; then
+    readlink -e /etc/nginx/sites-enabled/matsci-sam-public
+  else
+    echo absent
+  fi
+)"
+printf 'database_initialized\t%s\n' "$(
+  if command -v sudo >/dev/null &&
+    output=$(sudo -n /usr/local/sbin/matsci-sam-ops database-counts 2>/dev/null)
+  then
+    sed -n 's/^initialized=//p' <<<"${output}"
+  else
+    echo unavailable
+  fi
+)"
+installation_contract=$(
+  sudo -n /usr/local/sbin/matsci-sam-ops installation-contract 2>/dev/null ||
+    true
+)
+printf 'operations_sha256\t%s\n' "$(
+  sed -n 's/^matsci-sam-ops=//p' <<<"${installation_contract}" |
+    head -n 1
+)"
+printf 'sudoers_sha256\t%s\n' "$(
+  sed -n 's/^matsci-sam-ops.sudoers=//p' <<<"${installation_contract}" |
+    head -n 1
+)"
+for endpoint in root ready terms index; do
+  case ${endpoint} in
+    root) path=/ ;;
+    ready) path=/ready ;;
+    terms) path=/terms ;;
+    index) path=/index.html ;;
+  esac
+  endpoint_options=()
+  if [[ $(hostname) == cci-ego ]]; then
+    endpoint_options=(
+      --noproxy '*'
+      --resolve ego.cci.drexel.edu:443:127.0.0.1
+    )
+  fi
+  printf 'https_%s\t%s\n' "${endpoint}" "$(
+    curl \
+      --connect-timeout 3 \
+      --max-time 10 \
+      --silent \
+      --output /dev/null \
+      --write-out '%{http_code}' \
+      "${endpoint_options[@]}" \
+      "https://ego.cci.drexel.edu${path}" ||
+      echo unavailable
+  )"
+done
+printf 'ws10\t%s\n' "$(
+  if curl --connect-timeout 3 --max-time 8 --fail --silent \
+    http://ws10.cci.drexel.edu:11434/api/version >/dev/null
+  then
+    echo reachable
+  else
+    echo unavailable
+  fi
+)"
+REMOTE
+}
+
+declare -A superego=()
+declare -A ego=()
+while IFS=$'\t' read -r key value; do
+  [[ -n ${key} && -n ${value} ]] || continue
+  superego["${key}"]=${value}
+done < <(collect_remote superego)
+while IFS=$'\t' read -r key value; do
+  [[ -n ${key} && -n ${value} ]] || continue
+  ego["${key}"]=${value}
+done < <(collect_remote ego)
+
+check_equal() {
+  local label=$1
+  local actual=$2
+  local expected=$3
+  if [[ ${actual} == "${expected}" ]]; then
+    printf 'ok\t%s\t%s\n' "${label}" "${actual}"
+  else
+    printf 'mismatch\t%s\tactual=%s expected=%s\n' \
+      "${label}" "${actual}" "${expected}"
+    failures=$((failures + 1))
+  fi
+}
+
+printf 'Runtime parity contract\n'
+check_equal "Superego host" "${superego[host]:-missing}" cci-superego
+check_equal "Ego host" "${ego[host]:-missing}" cci-ego
+for target in superego ego; do
+  declare -n facts_ref="${target}"
+  check_equal "${target} Ubuntu" \
+    "${facts_ref[ubuntu]:-missing}" "${UBUNTU_VERSION}"
+  check_equal "${target} architecture" \
+    "${facts_ref[architecture]:-missing}" "${ARCHITECTURE}"
+  check_equal "${target} Nginx package" \
+    "${facts_ref[nginx_package]:-missing}" "${NGINX_PACKAGE_VERSION}"
+  check_equal "${target} Nginx service" \
+    "${facts_ref[nginx_service]:-missing}" active
+  check_equal "${target} ws10 route" \
+    "${facts_ref[ws10]:-missing}" reachable
+  unset -n facts_ref
+done
+
+check_equal "Superego Node package" \
+  "${superego[node_package]:-missing}" "${NODE_PACKAGE_VERSION}"
+check_equal "Superego Node" "${superego[node]:-missing}" "${NODE_VERSION}"
+check_equal "Superego pnpm" "${superego[pnpm]:-missing}" "${PNPM_VERSION}"
+check_equal "Superego PostgreSQL package" \
+  "${superego[postgres_package]:-missing}" "${POSTGRES_PACKAGE_VERSION}"
+check_equal "Superego postgresql-common package" \
+  "${superego[postgres_common_package]:-missing}" \
+  "${POSTGRES_COMMON_PACKAGE_VERSION}"
+check_equal "Superego pgvector package" \
+  "${superego[pgvector_package]:-missing}" "${PGVECTOR_PACKAGE_VERSION}"
+check_equal "Superego service unit" \
+  "${superego[service_unit_sha256]:-missing}" "${expected_service_sha}"
+check_equal "Superego data authority" \
+  "${superego[data_authority]:-missing}" superego
+check_equal "Superego PostgreSQL TCP" \
+  "${superego[postgres_tcp]:-missing}" closed
+check_equal "Superego application listener" \
+  "${superego[application_listener]:-missing}" 127.0.0.1:3000
+
+if [[ ${ego[node]:-missing} == absent &&
+  ${allow_unprovisioned_ego} == true ]]
+then
+  printf 'pending\tEgo application runtime\tnot provisioned\n'
+  check_equal "Ego data authority" \
+    "${ego[data_authority]:-missing}" absent
+  check_equal "Ego release" "${ego[release]:-missing}" absent
+  check_equal "Ego application listener" \
+    "${ego[application_listener]:-missing}" closed
+  check_equal "Ego active site" \
+    "${ego[active_site_target]:-missing}" \
+    /etc/nginx/sites-available/matsci-sam-public
+  check_equal "Ego active maintenance configuration" \
+    "${ego[maintenance_sha256]:-missing}" "${expected_maintenance_sha}"
+  check_equal "Ego HTTPS root" "${ego[https_root]:-missing}" 200
+  check_equal "Ego HTTPS ready" "${ego[https_ready]:-missing}" 200
+  check_equal "Ego HTTPS terms" "${ego[https_terms]:-missing}" 503
+  check_equal "Ego HTTPS direct index" "${ego[https_index]:-missing}" 404
+else
+  check_equal "Ego Node package" \
+    "${ego[node_package]:-missing}" "${NODE_PACKAGE_VERSION}"
+  check_equal "Ego Node" "${ego[node]:-missing}" "${NODE_VERSION}"
+  check_equal "Ego pnpm" "${ego[pnpm]:-missing}" "${PNPM_VERSION}"
+  check_equal "Ego PostgreSQL package" \
+    "${ego[postgres_package]:-missing}" "${POSTGRES_PACKAGE_VERSION}"
+  check_equal "Ego postgresql-common package" \
+    "${ego[postgres_common_package]:-missing}" \
+    "${POSTGRES_COMMON_PACKAGE_VERSION}"
+  check_equal "Ego pgvector package" \
+    "${ego[pgvector_package]:-missing}" "${PGVECTOR_PACKAGE_VERSION}"
+  check_equal "Ego service unit" \
+    "${ego[service_unit_sha256]:-missing}" "${expected_service_sha}"
+  check_equal "Ego PostgreSQL service" \
+    "${ego[postgres_service]:-missing}" active
+  case ${ego[data_authority]:-missing} in
+    uninitialized|ego)
+      printf 'ok\tEgo data authority\t%s\n' "${ego[data_authority]}"
+      ;;
+    *)
+      printf 'mismatch\tEgo data authority\t%s\n' \
+        "${ego[data_authority]:-missing}"
+      failures=$((failures + 1))
+      ;;
+  esac
+  check_equal "Ego PostgreSQL TCP" "${ego[postgres_tcp]:-missing}" closed
+  check_equal "Ego local proxy candidate" \
+    "${ego[local_candidate_sha256]:-missing}" "${expected_candidate_sha}"
+  check_equal "Ego diagnostic helper" \
+    "${ego[operations_sha256]:-missing}" "${expected_operations_sha}"
+  check_equal "Ego diagnostic sudo policy" \
+    "${ego[sudoers_sha256]:-missing}" "${expected_sudoers_sha}"
+
+  if [[ ${ego[data_authority]:-missing} == uninitialized ]]; then
+    check_equal "Ego database schema" \
+      "${ego[database_initialized]:-missing}" no
+    check_equal "Ego application service" \
+      "${ego[application_service]:-missing}" inactive
+    check_equal "Ego application enablement" \
+      "${ego[application_enabled]:-missing}" disabled
+    check_equal "Ego release" "${ego[release]:-missing}" absent
+    check_equal "Ego application listener" \
+      "${ego[application_listener]:-missing}" closed
+    check_equal "Ego active site" \
+      "${ego[active_site_target]:-missing}" \
+      /etc/nginx/sites-available/matsci-sam-public
+    check_equal "Ego active maintenance configuration" \
+      "${ego[maintenance_sha256]:-missing}" "${expected_maintenance_sha}"
+    check_equal "Ego HTTPS root" "${ego[https_root]:-missing}" 200
+    check_equal "Ego HTTPS ready" "${ego[https_ready]:-missing}" 200
+    check_equal "Ego HTTPS terms" "${ego[https_terms]:-missing}" 503
+    check_equal "Ego HTTPS direct index" "${ego[https_index]:-missing}" 404
+  elif [[ ${ego[data_authority]:-missing} == ego ]]; then
+    check_equal "Ego database schema" \
+      "${ego[database_initialized]:-missing}" yes
+    check_equal "Ego application service" \
+      "${ego[application_service]:-missing}" active
+    check_equal "Ego application enablement" \
+      "${ego[application_enabled]:-missing}" enabled
+    check_equal "Ego application listener" \
+      "${ego[application_listener]:-missing}" 127.0.0.1:3000
+    check_equal "Ego active site" \
+      "${ego[active_site_target]:-missing}" \
+      /etc/nginx/sites-available/matsci-sam-public-local-ready
+    check_equal "Ego HTTPS root" "${ego[https_root]:-missing}" 200
+    check_equal "Ego HTTPS ready" "${ego[https_ready]:-missing}" 200
+  fi
+fi
+
+printf 'state\tSuperego release\t%s\n' "${superego[release]:-missing}"
+printf 'state\tEgo release\t%s\n' "${ego[release]:-missing}"
+printf 'state\tEgo application service\t%s\n' \
+  "${ego[application_service]:-missing}"
+
+if ((failures > 0)); then
+  printf 'Runtime parity check failed with %s mismatch(es).\n' "${failures}" >&2
+  exit 1
+fi
+echo "Runtime parity check passed."

--- a/deploy/ego/AGENTS.md
+++ b/deploy/ego/AGENTS.md
@@ -1,0 +1,43 @@
+# Ego administration workspace
+
+This user-owned workspace supports the independent public MatSci SAM runtime
+at `ego.cci.drexel.edu`.
+
+## Ownership
+
+- GitHub `origin/dev` is the reviewed development source.
+- Superego is the private development runtime and shared-test database.
+- A reviewed tree promoted to `origin/main` is the public release source.
+- Ego owns its public TLS, Nginx, application releases, protected
+  configuration, and PostgreSQL database.
+- PA90 is the control workstation for tests, release preparation, and
+  deployment initiation.
+
+Run `$manage-matsci-environments` and inspect live state before acting.
+
+## Rules
+
+- Keep the HTTPS maintenance configuration active until an approved public
+  release, database seed, OAuth configuration, and cutover have passed.
+- Never edit `/opt/matsci-sam/current` or a release directory in place.
+- Never print or copy `/etc/matsci-sam/app.env`, database credentials, OAuth
+  secrets, session secrets, authentication tokens, or TLS private keys.
+- The initial `DATA-AUTHORITY` value is `uninitialized`. A reviewed one-time
+  seed may change it to `ego`. After that change, never replace or refresh the
+  Ego database from Superego.
+- No public deployment wrapper exists yet. Do not deploy an application
+  release, initialize data, or enable Nginx until those separate wrappers are
+  reviewed. A future public candidate must first pass on Superego.
+- Keep PostgreSQL and the Next.js listener local to Ego. PostgreSQL uses the
+  Unix socket, and Next.js listens only on `127.0.0.1:3000`.
+- Inspect the complete effective Nginx configuration before a change. Back up
+  the active site, validate with `nginx -t`, and retain maintenance mode for
+  rollback.
+- Ask the user to enter sudo for one reviewed command. Never request or handle
+  the password.
+- Keep `incoming/` temporary and remove staged files after a completed or
+  cancelled operation.
+- Do not create a source worktree or copied rolling-state document here.
+
+Exact commits, releases, database facts, and data-authority state are recorded
+only in `docs-internal/CURRENT-DEV-STATE.md` on PA90.

--- a/deploy/ego/app.env.example
+++ b/deploy/ego/app.env.example
@@ -1,28 +1,30 @@
-# Superego development profile. Ego uses deploy/ego/app.env.example.
-# NEXT_PUBLIC_SITE_URL is compiled into browser assets during `pnpm build`.
-NEXT_PUBLIC_SITE_URL=https://superego.cci.drexel.edu
+# Public application origin. This value is compiled into browser assets.
+NEXT_PUBLIC_SITE_URL=https://ego.cci.drexel.edu
 NEXT_PUBLIC_SITE_NAME="MatSci SAM"
 
-# The service account maps to the same-named PostgreSQL role through local
-# Unix-socket peer authentication.
+# Local Unix-socket peer authentication. The service account, role, and
+# database use the same name.
 DATABASE_URL=postgresql:///matsci-sam?host=/var/run/postgresql
 
+# Use a separate Ego Google Web client. The public client credentials remain
+# blank until the protected configuration step.
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
-GOOGLE_CALLBACK_URL=https://superego.cci.drexel.edu/api/auth/callback
+GOOGLE_CALLBACK_URL=https://ego.cci.drexel.edu/api/auth/callback
 GOOGLE_AUTH_ACCESS_MODE=existing-or-allowlisted
 GOOGLE_AUTH_ALLOWED_EMAILS=
 
+# Generated during provisioning. Never copy either value from Superego.
 SESSION_PASSWORD=
 SESSION_COOKIE_SECURE=true
 AUTH_TOKEN_ENCRYPTION_KEY=
 
 # Dormant ORCID OpenID Connect plumbing.
 ORCID_AUTH_ENABLED=false
-ORCID_ENVIRONMENT=sandbox
+ORCID_ENVIRONMENT=production
 ORCID_CLIENT_ID=
 ORCID_CLIENT_SECRET=
-ORCID_CALLBACK_URL=https://superego.cci.drexel.edu/api/auth/orcid/callback
+ORCID_CALLBACK_URL=https://ego.cci.drexel.edu/api/auth/orcid/callback
 ORCID_SCOPES=openid
 
 # Dormant verified-email authentication.
@@ -39,13 +41,12 @@ EMAIL_AUTH_SMTP_USER=
 EMAIL_AUTH_SMTP_PASSWORD=
 EMAIL_AUTH_TOKEN_TTL_MINUTES=15
 
-# Temporary development login. Remove these values after Google identity tests
-# have passed. Ego never enables this path.
+# Public deployments never expose the development login.
 DEV_AUTH_ENABLED=false
-# DEV_AUTH_USERS=
-# DEV_AUTH_PASSWORD=
 
-OLLAMA_HOST=
+# Private inference dependency. Verify connectivity and model readiness before
+# public activation.
+OLLAMA_HOST=http://ws10.cci.drexel.edu:11434
 SYSTEM_PROMPT_KEY=materials-reference
 REFINE_PROMPT_KEY=refine
 

--- a/deploy/lib/provision-ego-runtime-remote.sh
+++ b/deploy/lib/provision-ego-runtime-remote.sh
@@ -1,0 +1,888 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+umask 0077
+cd /
+
+stage=${1:-}
+app_user=matsci-sam
+app_group=matsci-sam
+app_root=/opt/matsci-sam
+app_state=/var/lib/matsci-sam
+app_config=/etc/matsci-sam
+database=matsci-sam
+database_role=matsci-sam
+authority_file=/home/cr625/ego-admin/DATA-AUTHORITY
+active_site=/etc/nginx/sites-available/matsci-sam-public
+active_link=/etc/nginx/sites-enabled/matsci-sam-public
+local_candidate=/etc/nginx/sites-available/matsci-sam-public-local-ready
+obsolete_proxy=/etc/nginx/sites-available/matsci-sam-public-proxy-ready
+agents_file=/home/cr625/ego-admin/AGENTS.md
+expected_edge_agents_sha=b3941b581bda98a73375c6c4dbd7962f3dd8f8fb6cfcce89dd605c161f9752d5
+expected_obsolete_proxy_sha=f25fc755a9a03d820f42bc4e35460616ccfb0c1dd2cd3ece5fb82ac49536bcfb
+expected_postgres_key_fingerprint=B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
+expected_nodesource_key_fingerprint=6F71F525282841EEDAF851B42F59B5F99B1BE0B4
+nodesource_key=
+postgres_key=
+candidate_test=
+generated_environment=
+authority_partial=
+admin_group=
+admin_gid=
+
+fail() {
+  echo "$*" >&2
+  exit 1
+}
+
+validate_environment_contract() {
+  local environment=$1
+  local environment_contract
+  local secret_count
+  local secret_key
+
+  [[ -f ${environment} && ! -L ${environment} &&
+    $(stat -c '%U:%G:%a' "${environment}") == "root:${app_group}:640" ]] ||
+    fail "The existing protected Ego environment has unexpected metadata."
+
+  environment_contract=$(
+    awk -F= '
+      BEGIN {
+        expected["NEXT_PUBLIC_SITE_URL"] = "https://ego.cci.drexel.edu"
+        expected["DATABASE_URL"] = "postgresql:///matsci-sam?host=/var/run/postgresql"
+        expected["GOOGLE_CALLBACK_URL"] = "https://ego.cci.drexel.edu/api/auth/callback"
+        expected["GOOGLE_AUTH_ACCESS_MODE"] = "existing-or-allowlisted"
+        expected["SESSION_COOKIE_SECURE"] = "true"
+        expected["ORCID_AUTH_ENABLED"] = "false"
+        expected["ORCID_CALLBACK_URL"] = "https://ego.cci.drexel.edu/api/auth/orcid/callback"
+        expected["EMAIL_AUTH_ENABLED"] = "false"
+        expected["DEV_AUTH_ENABLED"] = "false"
+        expected["OLLAMA_HOST"] = "http://ws10.cci.drexel.edu:11434"
+        expected["SYSTEM_PROMPT_KEY"] = "materials-reference"
+        expected["REFINE_PROMPT_KEY"] = "refine"
+      }
+      /^[[:space:]]*#/ || /^[[:space:]]*$/ { next }
+      {
+        key = $1
+        sub(/^[[:space:]]*/, "", key)
+        sub(/[[:space:]]*$/, "", key)
+        if (!(key in expected)) next
+        count[key]++
+        value = substr($0, index($0, "=") + 1)
+        sub(/^[[:space:]]*/, "", value)
+        sub(/[[:space:]]*$/, "", value)
+        if (value != expected[key]) bad[key] = 1
+      }
+      END {
+        for (key in expected) {
+          if (count[key] != 1 || bad[key]) print key
+        }
+      }
+    ' "${environment}"
+  )
+  [[ -z ${environment_contract} ]] ||
+    fail "The protected Ego environment differs from the public non-secret contract."
+
+  for secret_key in SESSION_PASSWORD AUTH_TOKEN_ENCRYPTION_KEY; do
+    secret_count=$(
+      awk -F= -v key="${secret_key}" '
+        $1 == key && length(substr($0, index($0, "=") + 1)) > 0 { count++ }
+        END { print count + 0 }
+      ' "${environment}"
+    )
+    [[ ${secret_count} == 1 ]] ||
+      fail "The protected Ego environment is missing a generated secret."
+  done
+}
+
+validate_database_contract() {
+  local application_relations
+  local database_exists
+  local database_owner
+  local role_contract
+  local role_exists
+
+  role_exists=$(
+    runuser -u postgres -- psql \
+      --host=/var/run/postgresql \
+      --port=5432 \
+      --dbname=postgres \
+      --no-align \
+      --tuples-only \
+      --command="SELECT count(*) FROM pg_roles WHERE rolname = '${database_role}'"
+  )
+  database_exists=$(
+    runuser -u postgres -- psql \
+      --host=/var/run/postgresql \
+      --port=5432 \
+      --dbname=postgres \
+      --no-align \
+      --tuples-only \
+      --command="SELECT count(*) FROM pg_database WHERE datname = '${database}'"
+  )
+
+  if [[ ${role_exists} == 0 && ${database_exists} == 0 ]]; then
+    return
+  fi
+  [[ ${role_exists} == 1 ]] ||
+    fail "The Ego application database exists without its reviewed role."
+
+  role_contract=$(
+    runuser -u postgres -- psql \
+      --host=/var/run/postgresql \
+      --port=5432 \
+      --dbname=postgres \
+      --no-align \
+      --tuples-only \
+      --command="
+        SELECT rolcanlogin
+            AND NOT rolsuper
+            AND NOT rolcreaterole
+            AND NOT rolcreatedb
+            AND NOT rolreplication
+            AND NOT rolbypassrls
+        FROM pg_roles
+        WHERE rolname = '${database_role}';
+      "
+  )
+  [[ ${role_contract} == t ]] ||
+    fail "The Ego database role differs from the least-privilege contract."
+
+  if [[ ${database_exists} == 0 ]]; then
+    return
+  fi
+  database_owner=$(
+    runuser -u postgres -- psql \
+      --host=/var/run/postgresql \
+      --port=5432 \
+      --dbname=postgres \
+      --no-align \
+      --tuples-only \
+      --command="
+        SELECT pg_get_userbyid(datdba)
+        FROM pg_database
+        WHERE datname = '${database}';
+      "
+  )
+  [[ ${database_owner} == "${database_role}" ]] ||
+    fail "The Ego application database has an unexpected owner."
+
+  application_relations=$(
+    runuser -u postgres -- psql \
+      --host=/var/run/postgresql \
+      --port=5432 \
+      --dbname="${database}" \
+      --no-align \
+      --tuples-only \
+      --command="
+        SELECT count(*)
+        FROM pg_class AS relation
+        JOIN pg_namespace AS namespace
+          ON namespace.oid = relation.relnamespace
+        WHERE namespace.nspname NOT IN ('pg_catalog', 'information_schema')
+          AND relation.relkind IN ('r', 'p', 'm', 'f');
+      "
+  )
+  [[ ${application_relations} == 0 ]] ||
+    fail "The uninitialized Ego database unexpectedly contains application relations."
+}
+
+cleanup() {
+  status=$?
+  trap - EXIT HUP INT TERM
+  [[ -z ${nodesource_key} || ! -e ${nodesource_key} ]] ||
+    rm -f "${nodesource_key}"
+  [[ -z ${postgres_key} || ! -e ${postgres_key} ]] ||
+    rm -f "${postgres_key}"
+  [[ -z ${candidate_test} || ! -e ${candidate_test} ]] ||
+    rm -f "${candidate_test}"
+  [[ -z ${generated_environment} || ! -e ${generated_environment} ]] ||
+    rm -f "${generated_environment}"
+  [[ -z ${authority_partial} || ! -e ${authority_partial} ]] ||
+    rm -f "${authority_partial}"
+  exit "${status}"
+}
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+[[ $(id -u) -eq 0 ]] || fail "Run this helper with sudo."
+[[ $(hostname) == cci-ego ]] || fail "This helper runs only on cci-ego."
+admin_group=$(id -gn cr625)
+admin_gid=$(id -g cr625)
+[[ -n ${admin_group} ]] || fail "Could not resolve the Ego administrator group."
+[[ ${admin_gid} =~ ^[0-9]+$ ]] || fail "Could not resolve the Ego administrator GID."
+[[ -d /home/cr625/ego-admin && ! -L /home/cr625/ego-admin &&
+  $(stat -c '%U:%G' /home/cr625/ego-admin) == "cr625:${admin_group}" ]] ||
+  fail "The Ego administration directory has unexpected metadata."
+[[ ${stage} =~ ^/home/cr625/ego-admin/incoming/provision-[0-9a-f]{12}-[0-9]{8}T[0-9]{6}Z$ ]] ||
+  fail "Invalid staging path."
+[[ -d ${stage} && ! -L ${stage} ]] ||
+  fail "The provisioning stage is unavailable."
+[[ $(stat -c '%U' "${stage}") == cr625 ]] ||
+  fail "Unexpected provisioning-stage owner."
+
+expected_stage_files=$(
+  printf '%s\n' \
+    AGENTS.md \
+    app.env.example \
+    manifest.tsv \
+    matsci-sam-ops \
+    matsci-sam-ops.sudoers \
+    matsci-sam-public-local-ready.conf \
+    matsci-sam-public-maintenance.conf \
+    matsci-sam.service \
+    provision-ego-runtime-remote.sh \
+    runtime-versions.env |
+    sort
+)
+actual_stage_files=$(
+  find "${stage}" -mindepth 1 -maxdepth 1 -printf '%f\n' | sort
+)
+[[ ${actual_stage_files} == "${expected_stage_files}" ]] ||
+  fail "The provisioning stage contains unexpected files."
+for staged_file in ${expected_stage_files}; do
+  [[ -f ${stage}/${staged_file} && ! -L ${stage}/${staged_file} ]] ||
+    fail "A provisioning-stage entry is not a regular file."
+done
+
+for command in awk cmp curl dpkg dpkg-query find flock getent grep gpg \
+  install nginx openssl runuser sha256sum systemctl visudo
+do
+  command -v "${command}" >/dev/null ||
+    fail "Required command is unavailable: ${command}"
+done
+
+declare -A manifest=()
+manifest_keys=(
+  format
+  source_host
+  source_commit
+  expected_authority
+  helper_sha256
+  versions_sha256
+  environment_sha256
+  service_sha256
+  maintenance_sha256
+  candidate_sha256
+  operations_sha256
+  sudoers_sha256
+  agents_sha256
+)
+is_manifest_key() {
+  local candidate=$1
+  local key
+  for key in "${manifest_keys[@]}"; do
+    [[ ${candidate} == "${key}" ]] && return 0
+  done
+  return 1
+}
+while IFS= read -r line || [[ -n ${line} ]]; do
+  [[ ${line} == *$'\t'* ]] || fail "Malformed manifest line."
+  key=${line%%$'\t'*}
+  value=${line#*$'\t'}
+  [[ ${value} != *$'\t'* ]] || fail "Malformed manifest value."
+  is_manifest_key "${key}" || fail "Unknown manifest key."
+  [[ ! -v "manifest[${key}]" ]] || fail "Duplicate manifest key."
+  [[ -n ${value} ]] || fail "Empty manifest value."
+  manifest["${key}"]=${value}
+done <"${stage}/manifest.tsv"
+for key in "${manifest_keys[@]}"; do
+  [[ -v "manifest[${key}]" ]] || fail "The provisioning manifest is incomplete."
+done
+[[ ${manifest[format]} == 1 ]] || fail "Unsupported manifest format."
+[[ ${manifest[source_host]} == pa90 ]] || fail "Unexpected provisioning source."
+[[ ${manifest[source_commit]} =~ ^[0-9a-f]{40}$ ]] ||
+  fail "Invalid source commit."
+[[ ${manifest[expected_authority]} == absent ||
+  ${manifest[expected_authority]} == uninitialized ]] ||
+  fail "Invalid expected Ego data authority."
+for key in helper_sha256 versions_sha256 environment_sha256 service_sha256 \
+  maintenance_sha256 candidate_sha256 operations_sha256 sudoers_sha256 \
+  agents_sha256
+do
+  [[ ${manifest[${key}]} =~ ^[0-9a-f]{64}$ ]] ||
+    fail "Invalid manifest SHA-256 value."
+done
+
+declare -A files_by_hash=(
+  [helper_sha256]=provision-ego-runtime-remote.sh
+  [versions_sha256]=runtime-versions.env
+  [environment_sha256]=app.env.example
+  [service_sha256]=matsci-sam.service
+  [maintenance_sha256]=matsci-sam-public-maintenance.conf
+  [candidate_sha256]=matsci-sam-public-local-ready.conf
+  [operations_sha256]=matsci-sam-ops
+  [sudoers_sha256]=matsci-sam-ops.sudoers
+  [agents_sha256]=AGENTS.md
+)
+for key in "${!files_by_hash[@]}"; do
+  file=${files_by_hash[${key}]}
+  actual_sha=$(sha256sum "${stage}/${file}" | awk '{print $1}')
+  [[ ${actual_sha} == "${manifest[${key}]}" ]] ||
+    fail "Provisioning file hash mismatch: ${file}"
+done
+
+declare -A versions=()
+version_keys=(
+  UBUNTU_VERSION
+  ARCHITECTURE
+  NGINX_PACKAGE_VERSION
+  NODE_PACKAGE_VERSION
+  NODE_VERSION
+  PNPM_VERSION
+  POSTGRES_MAJOR
+  POSTGRES_COMMON_PACKAGE_VERSION
+  POSTGRES_PACKAGE_VERSION
+  PGVECTOR_PACKAGE_VERSION
+)
+is_version_key() {
+  local candidate=$1
+  local key
+  for key in "${version_keys[@]}"; do
+    [[ ${candidate} == "${key}" ]] && return 0
+  done
+  return 1
+}
+while IFS= read -r line || [[ -n ${line} ]]; do
+  [[ ${line} =~ ^[[:space:]]*# || ${line} =~ ^[[:space:]]*$ ]] && continue
+  [[ ${line} == *=* ]] || fail "Malformed runtime-version line."
+  key=${line%%=*}
+  value=${line#*=}
+  is_version_key "${key}" || fail "Unknown runtime-version key."
+  [[ ! -v "versions[${key}]" && -n ${value} ]] ||
+    fail "Duplicate or empty runtime-version key."
+  [[ ${value} =~ ^[A-Za-z0-9.+:~-]+$ ]] ||
+    fail "Unsafe runtime-version value."
+  versions["${key}"]=${value}
+done <"${stage}/runtime-versions.env"
+for key in "${version_keys[@]}"; do
+  [[ -v "versions[${key}]" ]] || fail "The runtime-version contract is incomplete."
+done
+[[ ${versions[POSTGRES_MAJOR]} =~ ^[0-9]+$ ]] ||
+  fail "Invalid PostgreSQL major version."
+node_major=${versions[NODE_VERSION]#v}
+node_major=${node_major%%.*}
+[[ ${node_major} =~ ^[0-9]+$ ]] ||
+  fail "Invalid Node.js major version."
+
+. /etc/os-release
+[[ ${ID} == ubuntu && ${VERSION_ID} == "${versions[UBUNTU_VERSION]}" ]] ||
+  fail "Ego does not match the reviewed Ubuntu version."
+[[ $(dpkg --print-architecture) == "${versions[ARCHITECTURE]}" ]] ||
+  fail "Ego does not match the reviewed architecture."
+[[ $(dpkg-query -W -f='${Version}' nginx) == \
+  "${versions[NGINX_PACKAGE_VERSION]}" ]] ||
+  fail "Ego Nginx differs from the reviewed runtime contract."
+[[ $(systemctl is-active nginx.service) == active ]] ||
+  fail "Ego Nginx is not active."
+[[ -L ${active_link} && $(readlink -e "${active_link}") == "${active_site}" ]] ||
+  fail "The expected Ego maintenance site is not the active site."
+cmp --silent "${stage}/matsci-sam-public-maintenance.conf" "${active_site}" ||
+  fail "The active Ego maintenance configuration differs from the reviewed copy."
+[[ $(sha256sum "${active_site}" | awk '{print $1}') == \
+  "${manifest[maintenance_sha256]}" ]] ||
+  fail "The active Ego maintenance checksum is unexpected."
+[[ ! -e /opt/matsci-sam/current && ! -L /opt/matsci-sam/current ]] ||
+  fail "Ego already has an application release pointer."
+[[ $(systemctl is-active matsci-sam.service 2>/dev/null || true) != active ]] ||
+  fail "The Ego application service is already active."
+[[ -f ${agents_file} && ! -L ${agents_file} &&
+  $(stat -c '%U' "${agents_file}") == cr625 ]] ||
+  fail "The Ego administration rules are unavailable."
+agents_sha=$(sha256sum "${agents_file}" | awk '{print $1}')
+[[ ${agents_sha} == "${expected_edge_agents_sha}" ||
+  ${agents_sha} == "${manifest[agents_sha256]}" ]] ||
+  fail "The Ego administration rules changed after review."
+if [[ -e ${authority_file} || -L ${authority_file} ]]; then
+  [[ -f ${authority_file} && ! -L ${authority_file} &&
+    $(stat -c '%U:%a' "${authority_file}") == "cr625:600" ]] ||
+    fail "The existing Ego data-authority marker has unexpected metadata."
+  remote_authority=$(<"${authority_file}")
+else
+  remote_authority=absent
+fi
+[[ ${remote_authority} == "${manifest[expected_authority]}" ]] ||
+  fail "The recorded and live Ego data authorities disagree."
+if [[ -e ${obsolete_proxy} || -L ${obsolete_proxy} ]]; then
+  [[ -f ${obsolete_proxy} && ! -L ${obsolete_proxy} &&
+    $(stat -c '%U:%G:%a' "${obsolete_proxy}") == root:root:644 &&
+    $(sha256sum "${obsolete_proxy}" | awk '{print $1}') == \
+      "${expected_obsolete_proxy_sha}" ]] ||
+    fail "The obsolete Superego proxy candidate differs from the retired artifact."
+fi
+
+validate_collision() {
+  local installed=$1
+  local reviewed=$2
+  local metadata=$3
+  if [[ -e ${installed} || -L ${installed} ]]; then
+    [[ -f ${installed} && ! -L ${installed} &&
+      $(stat -c '%U:%G:%a' "${installed}") == "${metadata}" ]] ||
+      fail "An existing provisioning target has unexpected metadata: ${installed}"
+    cmp --silent "${reviewed}" "${installed}" ||
+      fail "An existing provisioning target differs from reviewed source: ${installed}"
+  fi
+}
+validate_collision \
+  /etc/systemd/system/matsci-sam.service \
+  "${stage}/matsci-sam.service" \
+  root:root:644
+validate_collision \
+  /usr/local/sbin/matsci-sam-ops \
+  "${stage}/matsci-sam-ops" \
+  root:root:755
+validate_collision \
+  /etc/sudoers.d/matsci-sam-ops \
+  "${stage}/matsci-sam-ops.sudoers" \
+  root:root:440
+validate_collision \
+  "${local_candidate}" \
+  "${stage}/matsci-sam-public-local-ready.conf" \
+  root:root:644
+if [[ -e /etc/systemd/system/matsci-sam.service ]]; then
+  [[ $(systemctl is-enabled matsci-sam.service 2>/dev/null || true) == disabled ]] ||
+    fail "The existing Ego application service is not disabled."
+fi
+
+if getent group "${app_group}" >/dev/null; then
+  app_group_id=$(getent group "${app_group}" | awk -F: '{print $3}')
+  [[ ${app_group_id} =~ ^[0-9]+$ && ${app_group_id} -lt 1000 ]] ||
+    fail "The existing application group is not a system group."
+fi
+if id "${app_user}" >/dev/null 2>&1; then
+  [[ $(id -gn "${app_user}") == "${app_group}" &&
+    $(getent passwd "${app_user}" | awk -F: '{print $6 ":" $7}') == \
+      "${app_state}:/usr/sbin/nologin" ]] ||
+    fail "The existing application service account differs from the reviewed contract."
+fi
+if [[ -e ${app_config}/app.env || -L ${app_config}/app.env ]]; then
+  getent group "${app_group}" >/dev/null ||
+    fail "The protected Ego environment exists without its application group."
+  validate_environment_contract "${app_config}/app.env"
+fi
+
+package_matches_or_absent() {
+  local package=$1
+  local expected=$2
+  local installed
+  installed=$(dpkg-query -W -f='${Version}' "${package}" 2>/dev/null || true)
+  [[ -z ${installed} || ${installed} == "${expected}" ]] ||
+    fail "An existing ${package} package differs from the reviewed contract."
+}
+package_matches_or_absent nodejs "${versions[NODE_PACKAGE_VERSION]}"
+package_matches_or_absent \
+  postgresql-common \
+  "${versions[POSTGRES_COMMON_PACKAGE_VERSION]}"
+package_matches_or_absent \
+  "postgresql-${versions[POSTGRES_MAJOR]}" \
+  "${versions[POSTGRES_PACKAGE_VERSION]}"
+package_matches_or_absent \
+  "postgresql-${versions[POSTGRES_MAJOR]}-pgvector" \
+  "${versions[PGVECTOR_PACKAGE_VERSION]}"
+if command -v pnpm >/dev/null; then
+  [[ $(pnpm --version) == "${versions[PNPM_VERSION]}" ]] ||
+    fail "An existing pnpm installation differs from the reviewed contract."
+fi
+if dpkg-query -W "postgresql-${versions[POSTGRES_MAJOR]}" >/dev/null 2>&1; then
+  [[ $(systemctl is-active postgresql.service 2>/dev/null || true) == active ]] ||
+    fail "An existing PostgreSQL installation is not active; inspect the partial run."
+  validate_database_contract
+fi
+
+candidate_test=$(mktemp)
+{
+  printf 'pid /run/nginx-matsci-candidate-test.pid;\n'
+  printf 'events {}\n'
+  printf 'http {\n'
+  printf '    include /etc/nginx/mime.types;\n'
+  printf '    include %s;\n' "${stage}/matsci-sam-public-local-ready.conf"
+  printf '}\n'
+} >"${candidate_test}"
+nginx -t -c "${candidate_test}"
+rm -f "${candidate_test}"
+candidate_test=
+
+nginx -T >/dev/null
+for path in / /ready /terms /index.html; do
+  code=$(
+    curl \
+      --connect-timeout 3 \
+      --max-time 10 \
+      --silent \
+      --show-error \
+      --noproxy '*' \
+      --resolve ego.cci.drexel.edu:443:127.0.0.1 \
+      --output /dev/null \
+      --write-out '%{http_code}' \
+      "https://ego.cci.drexel.edu${path}"
+  )
+  case ${path}:${code} in
+    /:200|/ready:200|/terms:503|/index.html:404) ;;
+    *) fail "The Ego maintenance contract failed for ${path}: ${code}" ;;
+  esac
+done
+
+exec 9>/run/lock/matsci-sam-operation.lock
+flock --nonblock 9 || fail "Another MatSci operation is running."
+
+export DEBIAN_FRONTEND=noninteractive
+stamp=$(date -u +%Y%m%dT%H%M%SZ)
+config_backup=/root/matsci-ego-before-runtime-${stamp}
+install -d -o root -g root -m 0700 "${config_backup}"
+install -o root -g root -m 0600 "${agents_file}" "${config_backup}/AGENTS.md"
+install -o cr625 -g "${admin_gid}" -m 0644 \
+  "${stage}/AGENTS.md" \
+  "${agents_file}"
+if [[ -e ${obsolete_proxy} ]]; then
+  install -o root -g root -m 0600 \
+    "${obsolete_proxy}" \
+    "${config_backup}/matsci-sam-public-proxy-ready.retired"
+fi
+
+echo "Installing the reviewed application runtime packages."
+apt-get update
+apt-get install -y \
+  build-essential \
+  ca-certificates \
+  curl \
+  git \
+  gnupg \
+  jq \
+  openssl \
+  xz-utils
+
+install -d -m 0755 /usr/share/postgresql-common/pgdg
+postgres_key=$(mktemp)
+curl --fail --silent --show-error \
+  https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+  -o "${postgres_key}"
+postgres_key_fingerprint=$(
+  gpg --batch --show-keys --with-colons "${postgres_key}" |
+    awk -F: '$1 == "fpr" { print $10; exit }'
+)
+[[ ${postgres_key_fingerprint} == "${expected_postgres_key_fingerprint}" ]] ||
+  fail "The PostgreSQL repository signing key fingerprint changed."
+install -o root -g root -m 0644 \
+  "${postgres_key}" \
+  /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc
+rm -f "${postgres_key}"
+postgres_key=
+cat >/etc/apt/sources.list.d/pgdg.sources <<EOF
+Types: deb
+URIs: https://apt.postgresql.org/pub/repos/apt
+Suites: ${VERSION_CODENAME}-pgdg
+Components: main
+Architectures: ${versions[ARCHITECTURE]}
+Signed-By: /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc
+EOF
+
+install -d -m 0755 /etc/apt/keyrings
+nodesource_key=$(mktemp)
+curl --fail --silent --show-error \
+  https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+  -o "${nodesource_key}"
+nodesource_key_fingerprint=$(
+  gpg --batch --show-keys --with-colons "${nodesource_key}" |
+    awk -F: '$1 == "fpr" { print $10; exit }'
+)
+[[ ${nodesource_key_fingerprint} == "${expected_nodesource_key_fingerprint}" ]] ||
+  fail "The NodeSource repository signing key fingerprint changed."
+gpg --batch --yes --dearmor \
+  --output /etc/apt/keyrings/nodesource.gpg \
+  "${nodesource_key}"
+chmod 0644 /etc/apt/keyrings/nodesource.gpg
+cat >/etc/apt/sources.list.d/nodesource.sources <<EOF
+Types: deb
+URIs: https://deb.nodesource.com/node_${node_major}.x
+Suites: nodistro
+Components: main
+Architectures: ${versions[ARCHITECTURE]}
+Signed-By: /etc/apt/keyrings/nodesource.gpg
+EOF
+
+apt-get update
+package_version_available() {
+  local package=$1
+  local version=$2
+  apt-cache madison "${package}" |
+    awk -F '|' -v expected="${version}" '
+      {
+        candidate = $2
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", candidate)
+        if (candidate == expected) found = 1
+      }
+      END { exit found ? 0 : 1 }
+    '
+}
+package_version_available nodejs "${versions[NODE_PACKAGE_VERSION]}" ||
+  fail "The reviewed Node.js package is unavailable."
+package_version_available \
+  postgresql-common \
+  "${versions[POSTGRES_COMMON_PACKAGE_VERSION]}" ||
+  fail "The reviewed postgresql-common package is unavailable."
+package_version_available \
+  "postgresql-${versions[POSTGRES_MAJOR]}" \
+  "${versions[POSTGRES_PACKAGE_VERSION]}" ||
+  fail "The reviewed PostgreSQL package is unavailable."
+package_version_available \
+  "postgresql-${versions[POSTGRES_MAJOR]}-pgvector" \
+  "${versions[PGVECTOR_PACKAGE_VERSION]}" ||
+  fail "The reviewed pgvector package is unavailable."
+
+apt-get install -y \
+  "nodejs=${versions[NODE_PACKAGE_VERSION]}" \
+  "postgresql-common=${versions[POSTGRES_COMMON_PACKAGE_VERSION]}" \
+  "postgresql-${versions[POSTGRES_MAJOR]}=${versions[POSTGRES_PACKAGE_VERSION]}" \
+  "postgresql-${versions[POSTGRES_MAJOR]}-pgvector=${versions[PGVECTOR_PACKAGE_VERSION]}"
+npm install --global "pnpm@${versions[PNPM_VERSION]}"
+
+[[ $(node --version) == "${versions[NODE_VERSION]}" ]] ||
+  fail "Installed Node.js differs from the runtime contract."
+[[ $(pnpm --version) == "${versions[PNPM_VERSION]}" ]] ||
+  fail "Installed pnpm differs from the runtime contract."
+[[ $(dpkg-query -W -f='${Version}' postgresql-common) == \
+  "${versions[POSTGRES_COMMON_PACKAGE_VERSION]}" ]] ||
+  fail "Installed postgresql-common differs from the runtime contract."
+[[ $(dpkg-query -W -f='${Version}' "postgresql-${versions[POSTGRES_MAJOR]}") == \
+  "${versions[POSTGRES_PACKAGE_VERSION]}" ]] ||
+  fail "Installed PostgreSQL differs from the runtime contract."
+[[ $(dpkg-query -W -f='${Version}' \
+  "postgresql-${versions[POSTGRES_MAJOR]}-pgvector") == \
+  "${versions[PGVECTOR_PACKAGE_VERSION]}" ]] ||
+  fail "Installed pgvector differs from the runtime contract."
+
+echo "Creating the standard MatSci SAM account and directories."
+if ! getent group "${app_group}" >/dev/null; then
+  groupadd --system "${app_group}"
+fi
+if ! id "${app_user}" >/dev/null 2>&1; then
+  useradd \
+    --system \
+    --gid "${app_group}" \
+    --home-dir "${app_state}" \
+    --create-home \
+    --shell /usr/sbin/nologin \
+    "${app_user}"
+fi
+[[ $(id -gn "${app_user}") == "${app_group}" &&
+  $(getent passwd "${app_user}" | awk -F: '{print $6 ":" $7}') == \
+    "${app_state}:/usr/sbin/nologin" ]] ||
+  fail "The application service account differs from the reviewed contract."
+install -d -o root -g "${app_group}" -m 2775 \
+  "${app_root}" \
+  "${app_root}/releases" \
+  "${app_root}/shared"
+install -d -o root -g "${app_group}" -m 0750 "${app_config}"
+install -d -o "${app_user}" -g "${app_group}" -m 0750 "${app_state}"
+
+if [[ ! -e ${app_config}/app.env && ! -L ${app_config}/app.env ]]; then
+  session_password=$(openssl rand -hex 32)
+  auth_encryption_key=$(openssl rand -base64 32 | tr -d '\n')
+  generated_environment=$(mktemp)
+  awk \
+    -v session_password="${session_password}" \
+    -v auth_encryption_key="${auth_encryption_key}" '
+      /^SESSION_PASSWORD=$/ {
+        print "SESSION_PASSWORD=" session_password
+        next
+      }
+      /^AUTH_TOKEN_ENCRYPTION_KEY=$/ {
+        print "AUTH_TOKEN_ENCRYPTION_KEY=" auth_encryption_key
+        next
+      }
+      { print }
+    ' "${stage}/app.env.example" >"${generated_environment}"
+  install -o root -g "${app_group}" -m 0640 \
+    "${generated_environment}" \
+    "${app_config}/app.env"
+  rm -f "${generated_environment}"
+  generated_environment=
+  unset session_password auth_encryption_key
+else
+  validate_environment_contract "${app_config}/app.env"
+fi
+
+validate_environment_contract "${app_config}/app.env"
+
+echo "Creating the socket-only PostgreSQL database."
+systemctl enable --now postgresql
+if ! runuser -u postgres -- psql \
+  --host=/var/run/postgresql \
+  --port=5432 \
+  --dbname=postgres \
+  --no-align \
+  --tuples-only \
+  --command="SELECT 1 FROM pg_roles WHERE rolname = '${database_role}'" |
+  grep -qx 1
+then
+  runuser -u postgres -- psql \
+    --host=/var/run/postgresql \
+    --port=5432 \
+    --dbname=postgres \
+    --set ON_ERROR_STOP=1 \
+    --command="CREATE ROLE \"${database_role}\" LOGIN"
+fi
+if ! runuser -u postgres -- psql \
+  --host=/var/run/postgresql \
+  --port=5432 \
+  --dbname=postgres \
+  --no-align \
+  --tuples-only \
+  --command="SELECT 1 FROM pg_database WHERE datname = '${database}'" |
+  grep -qx 1
+then
+  runuser -u postgres -- createdb \
+    --host=/var/run/postgresql \
+    --port=5432 \
+    --owner="${database_role}" \
+    "${database}"
+fi
+runuser -u postgres -- psql \
+  --host=/var/run/postgresql \
+  --port=5432 \
+  --dbname="${database}" \
+  --set ON_ERROR_STOP=1 \
+  --command="CREATE EXTENSION IF NOT EXISTS vector"
+validate_database_contract
+runuser -u postgres -- psql \
+  --host=/var/run/postgresql \
+  --port=5432 \
+  --dbname=postgres \
+  --set ON_ERROR_STOP=1 \
+  --command="ALTER SYSTEM SET listen_addresses TO ''"
+systemctl restart postgresql
+if ss -ltnH '( sport = :5432 )' | grep -q .; then
+  fail "PostgreSQL unexpectedly has a TCP listener."
+fi
+
+echo "Installing the disabled application service and diagnostic helper."
+if [[ -e /etc/systemd/system/matsci-sam.service ]] &&
+  ! cmp --silent \
+    "${stage}/matsci-sam.service" \
+    /etc/systemd/system/matsci-sam.service
+then
+  fail "An existing Ego application service differs from the reviewed unit."
+fi
+install -o root -g root -m 0644 \
+  "${stage}/matsci-sam.service" \
+  /etc/systemd/system/matsci-sam.service
+systemctl daemon-reload
+systemctl disable matsci-sam.service >/dev/null
+[[ $(systemctl is-active matsci-sam.service 2>/dev/null || true) != active ]] ||
+  fail "The application service became active during provisioning."
+[[ $(systemctl is-enabled matsci-sam.service 2>/dev/null || true) == disabled ]] ||
+  fail "The application service remains enabled after provisioning."
+
+if [[ -e /usr/local/sbin/matsci-sam-ops ]] &&
+  ! cmp --silent "${stage}/matsci-sam-ops" /usr/local/sbin/matsci-sam-ops
+then
+  fail "An existing diagnostic helper differs from the reviewed helper."
+fi
+install -o root -g root -m 0755 \
+  "${stage}/matsci-sam-ops" \
+  /usr/local/sbin/matsci-sam-ops
+visudo -cf "${stage}/matsci-sam-ops.sudoers" >/dev/null
+if [[ -e /etc/sudoers.d/matsci-sam-ops ]] &&
+  ! cmp --silent \
+    "${stage}/matsci-sam-ops.sudoers" \
+    /etc/sudoers.d/matsci-sam-ops
+then
+  fail "An existing diagnostic sudo policy differs from the reviewed policy."
+fi
+install -o root -g root -m 0440 \
+  "${stage}/matsci-sam-ops.sudoers" \
+  /etc/sudoers.d/matsci-sam-ops
+visudo -cf /etc/sudoers.d/matsci-sam-ops >/dev/null
+
+if [[ -e ${local_candidate} ]] &&
+  ! cmp --silent \
+    "${stage}/matsci-sam-public-local-ready.conf" \
+    "${local_candidate}"
+then
+  fail "An existing local application proxy candidate differs from the reviewed copy."
+fi
+install -o root -g root -m 0644 \
+  "${stage}/matsci-sam-public-local-ready.conf" \
+  "${local_candidate}"
+if [[ -e ${obsolete_proxy} || -L ${obsolete_proxy} ]]; then
+  rm -f "${obsolete_proxy}"
+fi
+
+if [[ -e ${authority_file} || -L ${authority_file} ]]; then
+  [[ -f ${authority_file} && ! -L ${authority_file} &&
+    $(stat -c '%U:%a' "${authority_file}") == "cr625:600" &&
+    $(<"${authority_file}") == uninitialized ]] ||
+    fail "The existing Ego data-authority marker is unexpected."
+else
+  authority_partial=$(mktemp)
+  printf 'uninitialized\n' >"${authority_partial}"
+  install -o cr625 -g "${admin_gid}" -m 0600 \
+    "${authority_partial}" \
+    "${authority_file}"
+  rm -f "${authority_partial}"
+  authority_partial=
+fi
+
+nginx -t
+[[ -L ${active_link} && $(readlink -e "${active_link}") == "${active_site}" ]] ||
+  fail "Provisioning changed the enabled Ego site."
+[[ $(sha256sum "${active_site}" | awk '{print $1}') == \
+  "${manifest[maintenance_sha256]}" ]] ||
+  fail "Provisioning changed the active Ego maintenance configuration."
+[[ $(systemctl is-active nginx.service) == active ]] ||
+  fail "Ego Nginx is inactive after provisioning."
+
+for path in / /ready /terms /index.html; do
+  code=$(
+    curl \
+      --connect-timeout 3 \
+      --max-time 10 \
+      --silent \
+      --show-error \
+      --noproxy '*' \
+      --resolve ego.cci.drexel.edu:443:127.0.0.1 \
+      --output /dev/null \
+      --write-out '%{http_code}' \
+      "https://ego.cci.drexel.edu${path}"
+  )
+  case ${path}:${code} in
+    /:200|/ready:200|/terms:503|/index.html:404) ;;
+    *) fail "The Ego maintenance contract failed after provisioning for ${path}: ${code}" ;;
+  esac
+done
+
+vector_version=$(
+  runuser -u postgres -- psql \
+    --host=/var/run/postgresql \
+    --port=5432 \
+    --dbname="${database}" \
+    --no-align \
+    --tuples-only \
+    --command="SELECT extversion FROM pg_extension WHERE extname = 'vector'"
+)
+database_initialized=$(
+  runuser -u postgres -- psql \
+    --host=/var/run/postgresql \
+    --port=5432 \
+    --dbname="${database}" \
+    --no-align \
+    --tuples-only \
+    --command="SELECT CASE WHEN to_regclass('public.users') IS NULL THEN 'no' ELSE 'yes' END"
+)
+
+printf '\nEgo application runtime provisioning completed.\n'
+printf 'source_commit=%s\n' "${manifest[source_commit]}"
+printf 'node=%s\n' "$(node --version)"
+printf 'pnpm=%s\n' "$(pnpm --version)"
+printf 'postgresql=%s\n' \
+  "$(runuser -u postgres -- psql --no-align --tuples-only --command='SHOW server_version')"
+printf 'pgvector=%s\n' "${vector_version}"
+printf 'database_initialized=%s\n' "${database_initialized}"
+printf 'data_authority=uninitialized\n'
+printf 'application_service=disabled\n'
+printf 'public_mode=maintenance\n'
+printf 'obsolete_superego_proxy=removed\n'
+printf 'configuration_backup=%s\n' "${config_backup}"

--- a/deploy/nginx/matsci-sam-public-local-ready.conf
+++ b/deploy/nginx/matsci-sam-public-local-ready.conf
@@ -1,0 +1,70 @@
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+upstream matsci_sam_local {
+    server 127.0.0.1:3000;
+    keepalive 32;
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+
+    server_name ego.cci.drexel.edu;
+
+    return 308 https://ego.cci.drexel.edu$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name ego.cci.drexel.edu;
+
+    ssl_certificate /etc/ssl/certs/ego.cci.drexel.edu.fullchain.pem;
+    ssl_certificate_key /etc/ssl/private/ego.cci.drexel.edu.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_session_cache shared:MatsciSAMEgoTLS:10m;
+    ssl_session_timeout 1d;
+    ssl_session_tickets off;
+
+    client_max_body_size 10m;
+
+    add_header Content-Security-Policy "base-uri 'self'; frame-ancestors 'none'; object-src 'none'" always;
+    add_header Permissions-Policy "camera=(), geolocation=(), microphone=()" always;
+    add_header Referrer-Policy "same-origin" always;
+    add_header Strict-Transport-Security "max-age=86400" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header X-Robots-Tag "noindex, nofollow" always;
+
+    location = /ready {
+        proxy_pass http://matsci_sam_local/api/health;
+        proxy_http_version 1.1;
+        proxy_set_header Host ego.cci.drexel.edu;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host ego.cci.drexel.edu;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_connect_timeout 3s;
+        proxy_read_timeout 10s;
+    }
+
+    location / {
+        proxy_pass http://matsci_sam_local;
+        proxy_http_version 1.1;
+
+        proxy_set_header Host ego.cci.drexel.edu;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host ego.cci.drexel.edu;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
+        proxy_connect_timeout 5s;
+        proxy_buffering off;
+        proxy_read_timeout 60s;
+    }
+}

--- a/deploy/nginx/matsci-sam-public-maintenance.conf
+++ b/deploy/nginx/matsci-sam-public-maintenance.conf
@@ -1,0 +1,61 @@
+server {
+    listen 80;
+    listen [::]:80;
+
+    server_name ego.cci.drexel.edu;
+
+    return 308 https://ego.cci.drexel.edu$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name ego.cci.drexel.edu;
+
+    ssl_certificate /etc/ssl/certs/ego.cci.drexel.edu.fullchain.pem;
+    ssl_certificate_key /etc/ssl/private/ego.cci.drexel.edu.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_session_cache shared:MatsciSAMEgoTLS:10m;
+    ssl_session_timeout 1d;
+    ssl_session_tickets off;
+
+    add_header Cache-Control "no-store" always;
+    add_header Content-Security-Policy "default-src 'none'; img-src 'self'; style-src 'self'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'" always;
+    add_header Referrer-Policy "no-referrer" always;
+    add_header Strict-Transport-Security "max-age=86400" always;
+    add_header X-Robots-Tag "noindex, nofollow" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+
+    location = /ready {
+        default_type text/plain;
+        return 200 "Ego HTTPS is ready; the MatSci SAM public proxy is disabled.\n";
+    }
+
+    location = / {
+        rewrite ^ /index.html last;
+    }
+
+    location = /index.html {
+        internal;
+        root /var/www/matsci-sam-maintenance;
+    }
+
+    location = /site.css {
+        alias /var/www/matsci-sam-maintenance/site.css;
+    }
+
+    location = /mrc-logo.png {
+        alias /var/www/matsci-sam-maintenance/mrc-logo.png;
+    }
+
+    location = /lattice.svg {
+        alias /var/www/matsci-sam-maintenance/lattice.svg;
+    }
+
+    location / {
+        default_type text/plain;
+        return 503 "MatSci SAM public trial is not open yet.\n";
+    }
+}

--- a/deploy/nginx/matsci-sam-superego.conf
+++ b/deploy/nginx/matsci-sam-superego.conf
@@ -3,20 +3,6 @@ map $http_upgrade $connection_upgrade {
     ''      close;
 }
 
-# Ego terminates public TLS and forwards to this private proxy. Only trust its
-# public address when preserving the original request protocol; direct VPN
-# clients cannot force Next.js to treat an HTTP request as HTTPS.
-geo $matsci_sam_from_public_proxy {
-    default       0;
-    129.25.202.67 1;
-}
-
-map "$matsci_sam_from_public_proxy:$http_x_forwarded_proto" $matsci_sam_forwarded_proto {
-    default   $scheme;
-    "1:http"  http;
-    "1:https" https;
-}
-
 upstream matsci_sam_nextjs {
     server 127.0.0.1:3000;
     keepalive 32;
@@ -26,9 +12,7 @@ server {
     listen 80;
     listen [::]:80;
 
-    # Keep both names valid at the proxy. NEXT_PUBLIC_SITE_URL controls the
-    # canonical application URL and can be changed independently at build time.
-    server_name ego.cci.drexel.edu superego.cci.drexel.edu sam.cci.drexel.edu;
+    server_name superego.cci.drexel.edu;
 
     client_max_body_size 10m;
 
@@ -40,7 +24,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Host $host;
-        proxy_set_header X-Forwarded-Proto $matsci_sam_forwarded_proto;
+        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $connection_upgrade;
 

--- a/deploy/ops/matsci-sam-ops
+++ b/deploy/ops/matsci-sam-ops
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+service=matsci-sam.service
+database=matsci-sam
+config=/etc/matsci-sam/app.env
+
+fail() {
+  echo "$*" >&2
+  exit 1
+}
+
+[[ ${EUID} -eq 0 ]] ||
+  fail "Run through sudo: sudo /usr/local/sbin/matsci-sam-ops <operation>"
+[[ $# -eq 1 ]] ||
+  fail "Allowed operations: status, runtime-summary, database-counts, config-presence, installation-contract"
+
+case $1 in
+  status)
+    systemctl show \
+      --no-pager \
+      --property=ActiveState \
+      --property=SubState \
+      --property=UnitFileState \
+      "${service}"
+    ;;
+  runtime-summary)
+    printf 'host=%s\n' "$(hostname)"
+    printf 'node=%s\n' "$(node --version 2>/dev/null || echo unavailable)"
+    printf 'pnpm=%s\n' "$(pnpm --version 2>/dev/null || echo unavailable)"
+    printf 'postgres=%s\n' \
+      "$(psql --version 2>/dev/null | awk '{print $3}' || echo unavailable)"
+    printf 'pgvector=%s\n' "$(
+      runuser -u postgres -- psql \
+        --host=/var/run/postgresql \
+        --port=5432 \
+        --dbname="${database}" \
+        --no-align \
+        --tuples-only \
+        --command="SELECT extversion FROM pg_extension WHERE extname = 'vector'" \
+        2>/dev/null || echo unavailable
+    )"
+    printf 'application=%s\n' \
+      "$(systemctl is-active "${service}" 2>/dev/null || true)"
+    printf 'application_enabled=%s\n' \
+      "$(systemctl is-enabled "${service}" 2>/dev/null || true)"
+    printf 'release=%s\n' \
+      "$(readlink -e /opt/matsci-sam/current 2>/dev/null || echo unavailable)"
+    printf 'port_3000=%s\n' "$(
+      if ss -ltnH '( sport = :3000 )' | grep -q .; then
+        echo listening
+      else
+        echo closed
+      fi
+    )"
+    ;;
+  database-counts)
+    initialized=$(
+      runuser -u postgres -- psql \
+        --host=/var/run/postgresql \
+        --port=5432 \
+        --dbname="${database}" \
+        --no-align \
+        --tuples-only \
+        --command="
+          SELECT CASE
+            WHEN to_regclass('public.users') IS NOT NULL
+             AND to_regclass('public.terms') IS NOT NULL
+             AND to_regclass('public.definitions') IS NOT NULL
+             AND to_regclass('drizzle.__drizzle_migrations') IS NOT NULL
+            THEN 'yes'
+            ELSE 'no'
+          END;
+        "
+    )
+    printf 'initialized=%s\n' "${initialized}"
+    if [[ ${initialized} == yes ]]; then
+      runuser -u postgres -- psql \
+        --host=/var/run/postgresql \
+        --port=5432 \
+        --dbname="${database}" \
+        --no-align \
+        --tuples-only \
+        --command="
+          SELECT 'terms=' || count(*) FROM terms
+          UNION ALL
+          SELECT 'definitions=' || count(*) FROM definitions
+          UNION ALL
+          SELECT 'users=' || count(*) FROM users
+          UNION ALL
+          SELECT 'migrations=' || count(*)
+          FROM drizzle.__drizzle_migrations;
+        "
+    fi
+    ;;
+  config-presence)
+    [[ -f ${config} && ! -L ${config} ]] ||
+      fail "The protected application environment is unavailable."
+    awk -F= '
+      BEGIN {
+        split(
+          "NEXT_PUBLIC_SITE_URL NEXT_PUBLIC_SITE_NAME DATABASE_URL " \
+          "GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET GOOGLE_CALLBACK_URL " \
+          "GOOGLE_AUTH_ACCESS_MODE GOOGLE_AUTH_ALLOWED_EMAILS " \
+          "SESSION_PASSWORD SESSION_COOKIE_SECURE " \
+          "AUTH_TOKEN_ENCRYPTION_KEY ORCID_AUTH_ENABLED " \
+          "EMAIL_AUTH_ENABLED DEV_AUTH_ENABLED OLLAMA_HOST " \
+          "SYSTEM_PROMPT_KEY REFINE_PROMPT_KEY",
+          expected,
+          " "
+        )
+        for (i in expected) wanted[expected[i]] = 1
+      }
+      /^[[:space:]]*#/ || /^[[:space:]]*$/ { next }
+      {
+        key = $1
+        sub(/^[[:space:]]*/, "", key)
+        sub(/[[:space:]]*$/, "", key)
+        if (!(key in wanted)) next
+        count[key]++
+        value = substr($0, index($0, "=") + 1)
+        sub(/^[[:space:]]*/, "", value)
+        sub(/[[:space:]]*$/, "", value)
+        if (length(value) > 0) present[key] = 1
+      }
+      END {
+        for (i in expected) {
+          key = expected[i]
+          if (count[key] == 0) {
+            state = "missing"
+          } else if (count[key] > 1) {
+            state = "duplicate"
+          } else if (present[key]) {
+            state = "set"
+          } else {
+            state = "blank"
+          }
+          print key "=" state
+        }
+      }
+    ' "${config}" | sort
+    ;;
+  installation-contract)
+    for path in \
+      /usr/local/sbin/matsci-sam-ops \
+      /etc/sudoers.d/matsci-sam-ops \
+      /etc/systemd/system/matsci-sam.service \
+      /etc/nginx/sites-available/matsci-sam-public-local-ready
+    do
+      label=${path##*/}
+      if [[ -f ${path} && ! -L ${path} ]]; then
+        printf '%s=%s\n' \
+          "${label}" \
+          "$(sha256sum "${path}" | awk '{print $1}')"
+      else
+        printf '%s=unavailable\n' "${label}"
+      fi
+    done
+    ;;
+  *)
+    fail "Operation not permitted: $1"
+    ;;
+esac

--- a/deploy/ops/matsci-sam-ops.sudoers
+++ b/deploy/ops/matsci-sam-ops.sudoers
@@ -1,0 +1,5 @@
+cr625 ALL=(root) NOPASSWD: /usr/local/sbin/matsci-sam-ops status
+cr625 ALL=(root) NOPASSWD: /usr/local/sbin/matsci-sam-ops runtime-summary
+cr625 ALL=(root) NOPASSWD: /usr/local/sbin/matsci-sam-ops database-counts
+cr625 ALL=(root) NOPASSWD: /usr/local/sbin/matsci-sam-ops config-presence
+cr625 ALL=(root) NOPASSWD: /usr/local/sbin/matsci-sam-ops installation-contract

--- a/deploy/provision-ego-runtime.sh
+++ b/deploy/provision-ego-runtime.sh
@@ -1,0 +1,418 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+umask 0077
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+repo=$(cd -- "${script_dir}/.." && pwd)
+remote_helper=${script_dir}/lib/provision-ego-runtime-remote.sh
+versions_file=${script_dir}/runtime-versions.env
+environment_file=${script_dir}/ego/app.env.example
+agents_file=${script_dir}/ego/AGENTS.md
+service_file=${script_dir}/systemd/matsci-sam.service
+maintenance_file=${script_dir}/nginx/matsci-sam-public-maintenance.conf
+candidate_file=${script_dir}/nginx/matsci-sam-public-local-ready.conf
+operations_file=${script_dir}/ops/matsci-sam-ops
+sudoers_file=${script_dir}/ops/matsci-sam-ops.sudoers
+state_file=${repo}/docs-internal/CURRENT-DEV-STATE.md
+workstation_registry=${script_dir}/workstations.tsv
+check_only=false
+yes_provision=false
+remote_staged=false
+remote_dir=
+work_dir=
+
+usage() {
+  cat <<'USAGE'
+Usage: deploy/provision-ego-runtime.sh [options]
+
+Install the reviewed MatSci SAM runtime prerequisites on Ego while preserving
+the active HTTPS maintenance site. The command leaves the application
+disabled and the local database uninitialized.
+
+Options:
+  --yes-provision  Skip the provisioning confirmation prompt
+  --check-only     Validate source and non-privileged remote prerequisites
+  -h, --help       Show this help
+USAGE
+}
+
+fail() {
+  echo "$*" >&2
+  exit 1
+}
+
+cleanup() {
+  status=$?
+  trap - EXIT HUP INT TERM
+
+  if [[ ${remote_staged} == true && -n ${remote_dir} ]]; then
+    ssh -o BatchMode=yes ego \
+      "find '${remote_dir}' -mindepth 1 -delete 2>/dev/null || true; rmdir '${remote_dir}' 2>/dev/null || true" \
+      >/dev/null 2>&1 || true
+  fi
+
+  if [[ -n ${work_dir} && -d ${work_dir} ]]; then
+    find "${work_dir}" -mindepth 1 -delete
+    rmdir "${work_dir}"
+  fi
+
+  exit "${status}"
+}
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+while (($#)); do
+  case $1 in
+    --yes-provision)
+      yes_provision=true
+      shift
+      ;;
+    --check-only)
+      check_only=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+for command in awk git scp sha256sum ssh stat
+do
+  command -v "${command}" >/dev/null ||
+    fail "Required command is unavailable: ${command}"
+done
+
+required_files=(
+  "${remote_helper}"
+  "${versions_file}"
+  "${environment_file}"
+  "${agents_file}"
+  "${service_file}"
+  "${maintenance_file}"
+  "${candidate_file}"
+  "${operations_file}"
+  "${sudoers_file}"
+  "${state_file}"
+  "${workstation_registry}"
+)
+for file in "${required_files[@]}"; do
+  [[ -f ${file} && ! -L ${file} ]] ||
+    fail "Required provisioning file is missing or unsafe: ${file}"
+done
+
+current_hostname=$(hostname)
+registry_entry=$(
+  awk -F '\t' -v host="${current_hostname}" '
+    /^#/ || /^[[:space:]]*$/ { next }
+    NF != 3 { exit 2 }
+    $1 !~ /^[a-z][a-z0-9-]*$/ { exit 2 }
+    $2 !~ /^[A-Za-z0-9][A-Za-z0-9.-]*$/ { exit 2 }
+    $3 != "yes" && $3 != "no" { exit 2 }
+    ++seen_id[$1] > 1 || ++seen_host[$2] > 1 { exit 2 }
+    $2 == host { print $0 }
+  ' "${workstation_registry}"
+) || fail "The workstation registry is malformed."
+[[ -n ${registry_entry} && ${registry_entry} != *$'\n'* ]] ||
+  fail "This workstation is not uniquely registered for MatSci orchestration."
+IFS=$'\t' read -r workstation registered_hostname _ <<<"${registry_entry}"
+[[ ${registered_hostname} == "${current_hostname}" ]] ||
+  fail "The workstation registry did not resolve this host."
+
+control_workstation=$(
+  sed -n 's/^Control workstation: `\([^`]*\)`$/\1/p' "${state_file}"
+)
+[[ ${control_workstation} == "${workstation}" ]] ||
+  fail "This host is not the recorded MatSci control workstation."
+ego_state_authority=$(
+  sed -n 's/^Ego data authority: `\([^`]*\)`$/\1/p' "${state_file}"
+)
+case ${ego_state_authority} in
+  absent|uninitialized) ;;
+  ego)
+    fail "Ego already owns public data; runtime provisioning is no longer permitted."
+    ;;
+  *)
+    fail "The recorded Ego data authority is missing or invalid."
+    ;;
+esac
+
+origin_url=$(git -C "${repo}" remote get-url origin)
+case ${origin_url} in
+  https://github.com/metadata-research/matsci-yamz.git|\
+  git@github.com:metadata-research/matsci-yamz.git)
+    ;;
+  *)
+    fail "Refusing unexpected origin: ${origin_url}"
+    ;;
+esac
+
+git -C "${repo}" fetch --prune origin dev
+branch=$(git -C "${repo}" branch --show-current)
+[[ ${branch} == dev ]] ||
+  fail "Ego provisioning must run from the reviewed dev branch."
+if [[ -n $(git -C "${repo}" status --porcelain=v1) ]]; then
+  git -C "${repo}" status --short >&2
+  fail "The control-workstation worktree must be clean."
+fi
+source_commit=$(git -C "${repo}" rev-parse HEAD)
+origin_dev=$(git -C "${repo}" rev-parse refs/remotes/origin/dev)
+[[ ${source_commit} == "${origin_dev}" ]] ||
+  fail "HEAD and origin/dev must identify the same commit."
+
+maintenance_sha=$(sha256sum "${maintenance_file}" | awk '{print $1}')
+candidate_sha=$(sha256sum "${candidate_file}" | awk '{print $1}')
+agents_sha=$(sha256sum "${agents_file}" | awk '{print $1}')
+service_sha=$(sha256sum "${service_file}" | awk '{print $1}')
+operations_sha=$(sha256sum "${operations_file}" | awk '{print $1}')
+sudoers_sha=$(sha256sum "${sudoers_file}" | awk '{print $1}')
+
+remote_summary=$(
+  ssh -o BatchMode=yes -o ConnectTimeout=8 ego \
+    /bin/bash -s -- \
+    "${maintenance_sha}" \
+    "${candidate_sha}" \
+    "${agents_sha}" \
+    "${service_sha}" \
+    "${operations_sha}" \
+    "${sudoers_sha}" \
+    "${ego_state_authority}" <<'REMOTE'
+set -Eeuo pipefail
+expected_maintenance_sha=$1
+expected_candidate_sha=$2
+expected_agents_sha=$3
+expected_service_sha=$4
+expected_operations_sha=$5
+expected_sudoers_sha=$6
+expected_authority=$7
+old_agents_sha=b3941b581bda98a73375c6c4dbd7962f3dd8f8fb6cfcce89dd605c161f9752d5
+obsolete_proxy_sha=f25fc755a9a03d820f42bc4e35460616ccfb0c1dd2cd3ece5fb82ac49536bcfb
+
+[[ $(hostname) == cci-ego ]]
+[[ $(systemctl is-active nginx.service) == active ]]
+[[ -d /home/cr625/ego-admin && ! -L /home/cr625/ego-admin ]]
+[[ $(stat -c '%U' /home/cr625/ego-admin) == cr625 ]]
+if [[ -e /home/cr625/ego-admin/incoming ||
+  -L /home/cr625/ego-admin/incoming ]]
+then
+  [[ -d /home/cr625/ego-admin/incoming &&
+    ! -L /home/cr625/ego-admin/incoming &&
+    $(stat -c '%U:%a' /home/cr625/ego-admin/incoming) == cr625:700 ]]
+fi
+[[ -L /etc/nginx/sites-enabled/matsci-sam-public ]]
+[[ $(readlink -e /etc/nginx/sites-enabled/matsci-sam-public) == \
+  /etc/nginx/sites-available/matsci-sam-public ]]
+[[ $(sha256sum /etc/nginx/sites-available/matsci-sam-public | awk '{print $1}') == \
+  "${expected_maintenance_sha}" ]]
+agents_sha=$(
+  sha256sum /home/cr625/ego-admin/AGENTS.md | awk '{print $1}'
+)
+[[ ${agents_sha} == "${old_agents_sha}" ||
+  ${agents_sha} == "${expected_agents_sha}" ]]
+[[ ! -e /opt/matsci-sam/current && ! -L /opt/matsci-sam/current ]]
+[[ $(systemctl is-active matsci-sam.service 2>/dev/null || true) != active ]]
+if [[ -e /etc/systemd/system/matsci-sam.service ||
+  -L /etc/systemd/system/matsci-sam.service ]]
+then
+  [[ -f /etc/systemd/system/matsci-sam.service &&
+    ! -L /etc/systemd/system/matsci-sam.service ]]
+  [[ $(sha256sum /etc/systemd/system/matsci-sam.service | awk '{print $1}') == \
+    "${expected_service_sha}" ]]
+  [[ $(systemctl is-enabled matsci-sam.service 2>/dev/null || true) == disabled ]]
+fi
+if [[ -e /etc/nginx/sites-available/matsci-sam-public-local-ready ||
+  -L /etc/nginx/sites-available/matsci-sam-public-local-ready ]]
+then
+  [[ -f /etc/nginx/sites-available/matsci-sam-public-local-ready &&
+    ! -L /etc/nginx/sites-available/matsci-sam-public-local-ready ]]
+  [[ $(sha256sum /etc/nginx/sites-available/matsci-sam-public-local-ready |
+    awk '{print $1}') == "${expected_candidate_sha}" ]]
+fi
+if [[ -e /usr/local/sbin/matsci-sam-ops ||
+  -L /usr/local/sbin/matsci-sam-ops ]]
+then
+  [[ -f /usr/local/sbin/matsci-sam-ops &&
+    ! -L /usr/local/sbin/matsci-sam-ops ]]
+  [[ $(sha256sum /usr/local/sbin/matsci-sam-ops | awk '{print $1}') == \
+    "${expected_operations_sha}" ]]
+fi
+if [[ -e /etc/sudoers.d/matsci-sam-ops ||
+  -L /etc/sudoers.d/matsci-sam-ops ]]
+then
+  [[ -f /etc/sudoers.d/matsci-sam-ops &&
+    ! -L /etc/sudoers.d/matsci-sam-ops ]]
+  [[ $(stat -c '%U:%G:%a' /etc/sudoers.d/matsci-sam-ops) == root:root:440 ]]
+fi
+if id matsci-sam >/dev/null 2>&1; then
+  [[ $(id -gn matsci-sam) == matsci-sam ]]
+  [[ $(getent passwd matsci-sam | awk -F: '{print $6 ":" $7}') == \
+    /var/lib/matsci-sam:/usr/sbin/nologin ]]
+fi
+if [[ -e /etc/nginx/sites-available/matsci-sam-public-proxy-ready ||
+  -L /etc/nginx/sites-available/matsci-sam-public-proxy-ready ]]
+then
+  [[ -f /etc/nginx/sites-available/matsci-sam-public-proxy-ready &&
+    ! -L /etc/nginx/sites-available/matsci-sam-public-proxy-ready ]]
+  [[ $(sha256sum /etc/nginx/sites-available/matsci-sam-public-proxy-ready |
+    awk '{print $1}') == "${obsolete_proxy_sha}" ]]
+fi
+remote_authority=$(
+  if [[ -e /home/cr625/ego-admin/DATA-AUTHORITY ||
+    -L /home/cr625/ego-admin/DATA-AUTHORITY ]]
+  then
+    [[ -f /home/cr625/ego-admin/DATA-AUTHORITY &&
+      ! -L /home/cr625/ego-admin/DATA-AUTHORITY ]] || exit 1
+    sed -n '1p' /home/cr625/ego-admin/DATA-AUTHORITY
+  else
+    echo absent
+  fi
+)
+[[ ${remote_authority} == "${expected_authority}" ]]
+for path in / /ready /terms /index.html; do
+  code=$(
+    curl \
+      --connect-timeout 3 \
+      --max-time 10 \
+      --silent \
+      --show-error \
+      --noproxy '*' \
+      --resolve ego.cci.drexel.edu:443:127.0.0.1 \
+      --output /dev/null \
+      --write-out '%{http_code}' \
+      "https://ego.cci.drexel.edu${path}"
+  )
+  case ${path}:${code} in
+    /:200|/ready:200|/terms:503|/index.html:404) ;;
+    *) exit 1 ;;
+  esac
+done
+
+printf 'host=%s\n' "$(hostname)"
+printf 'maintenance_sha256=%s\n' "${expected_maintenance_sha}"
+printf 'node=%s\n' "$(node --version 2>/dev/null || echo absent)"
+printf 'pnpm=%s\n' "$(pnpm --version 2>/dev/null || echo absent)"
+printf 'postgresql=%s\n' "$(psql --version 2>/dev/null | awk '{print $3}' || echo absent)"
+printf 'data_authority=%s\n' "$(
+  printf '%s\n' "${remote_authority}"
+)"
+printf 'service_unit=%s\n' "$(
+  if [[ -f /etc/systemd/system/matsci-sam.service ]] &&
+    [[ $(sha256sum /etc/systemd/system/matsci-sam.service | awk '{print $1}') == \
+      "${expected_service_sha}" ]]
+  then
+    echo reviewed
+  else
+    echo absent-or-different
+  fi
+)"
+printf 'local_proxy_candidate=%s\n' "$(
+  if [[ -f /etc/nginx/sites-available/matsci-sam-public-local-ready ]] &&
+    [[ $(sha256sum /etc/nginx/sites-available/matsci-sam-public-local-ready |
+      awk '{print $1}') == "${expected_candidate_sha}" ]]
+  then
+    echo reviewed
+  else
+    echo absent-or-different
+  fi
+)"
+printf 'obsolete_superego_proxy=%s\n' "$(
+  if [[ -e /etc/nginx/sites-available/matsci-sam-public-proxy-ready ||
+    -L /etc/nginx/sites-available/matsci-sam-public-proxy-ready ]]
+  then
+    echo reviewed-retired-candidate
+  else
+    echo absent
+  fi
+)"
+printf 'ws10=%s\n' "$(
+  if curl --connect-timeout 3 --max-time 8 --fail --silent \
+    http://ws10.cci.drexel.edu:11434/api/version >/dev/null
+  then
+    echo reachable
+  else
+    echo unavailable
+  fi
+)"
+REMOTE
+) || fail "Ego did not pass the non-privileged provisioning preflight."
+
+printf '%s\n' "${remote_summary}"
+if [[ ${check_only} == true ]]; then
+  echo "Ego runtime provisioning prerequisites passed."
+  exit 0
+fi
+
+if [[ ${yes_provision} != true ]]; then
+  [[ -t 0 ]] || fail "Run interactively or pass --yes-provision."
+  printf '\nThis installs the independent Ego runtime and empty local database.\n'
+  printf 'The HTTPS maintenance site remains active and the application remains disabled.\n'
+  printf 'Type PROVISION EGO RUNTIME to continue: '
+  IFS= read -r confirmation
+  [[ ${confirmation} == "PROVISION EGO RUNTIME" ]] ||
+    fail "Provisioning cancelled."
+fi
+
+work_dir=$(mktemp -d)
+manifest=${work_dir}/manifest.tsv
+{
+  printf 'format\t1\n'
+  printf 'source_host\t%s\n' "${workstation}"
+  printf 'source_commit\t%s\n' "${source_commit}"
+  printf 'expected_authority\t%s\n' "${ego_state_authority}"
+  printf 'helper_sha256\t%s\n' \
+    "$(sha256sum "${remote_helper}" | awk '{print $1}')"
+  printf 'versions_sha256\t%s\n' \
+    "$(sha256sum "${versions_file}" | awk '{print $1}')"
+  printf 'environment_sha256\t%s\n' \
+    "$(sha256sum "${environment_file}" | awk '{print $1}')"
+  printf 'service_sha256\t%s\n' "${service_sha}"
+  printf 'maintenance_sha256\t%s\n' "${maintenance_sha}"
+  printf 'candidate_sha256\t%s\n' "${candidate_sha}"
+  printf 'operations_sha256\t%s\n' \
+    "${operations_sha}"
+  printf 'sudoers_sha256\t%s\n' \
+    "${sudoers_sha}"
+  printf 'agents_sha256\t%s\n' "${agents_sha}"
+} >"${manifest}"
+
+remote_id="provision-${source_commit:0:12}-$(date -u +%Y%m%dT%H%M%SZ)"
+remote_dir="/home/cr625/ego-admin/incoming/${remote_id}"
+ssh ego \
+  "set -Eeuo pipefail
+   install -d --mode=0700 /home/cr625/ego-admin/incoming
+   [[ \$(stat -c '%U:%a' /home/cr625/ego-admin/incoming) == cr625:700 ]]
+   mkdir --mode=0700 '${remote_dir}'"
+remote_staged=true
+scp \
+  "${agents_file}" \
+  "${environment_file}" \
+  "${manifest}" \
+  "${operations_file}" \
+  "${sudoers_file}" \
+  "${candidate_file}" \
+  "${maintenance_file}" \
+  "${service_file}" \
+  "${remote_helper}" \
+  "${versions_file}" \
+  "ego:${remote_dir}/"
+
+ssh -t ego \
+  "sudo bash '${remote_dir}/provision-ego-runtime-remote.sh' '${remote_dir}'"
+
+ssh ego \
+  "if [[ -d '${remote_dir}' ]]; then
+     find '${remote_dir}' -mindepth 1 -delete
+     rmdir '${remote_dir}'
+   fi"
+remote_staged=false
+echo "Ego runtime provisioning and maintenance verification completed."

--- a/deploy/runtime-versions.env
+++ b/deploy/runtime-versions.env
@@ -1,0 +1,13 @@
+# Reviewed runtime versions shared by the Superego development runtime and
+# the Ego public runtime. Provisioning refuses a different package candidate
+# until this file is updated through source review.
+UBUNTU_VERSION=24.04
+ARCHITECTURE=amd64
+NGINX_PACKAGE_VERSION=1.24.0-2ubuntu7.15
+NODE_PACKAGE_VERSION=24.18.0-1nodesource1
+NODE_VERSION=v24.18.0
+PNPM_VERSION=10.34.5
+POSTGRES_MAJOR=17
+POSTGRES_COMMON_PACKAGE_VERSION=293.pgdg24.04+1
+POSTGRES_PACKAGE_VERSION=17.10-1.pgdg24.04+1
+PGVECTOR_PACKAGE_VERSION=0.8.5-1.pgdg24.04+1

--- a/deploy/systemd/matsci-sam.service
+++ b/deploy/systemd/matsci-sam.service
@@ -13,7 +13,7 @@ Environment=NODE_ENV=production
 Environment=HOSTNAME=127.0.0.1
 Environment=PORT=3000
 EnvironmentFile=/etc/matsci-sam/app.env
-ExecStart=/usr/bin/pnpm start
+ExecStart=/usr/bin/pnpm exec next start --hostname 127.0.0.1 --port 3000
 Restart=on-failure
 RestartSec=5s
 TimeoutStopSec=30s

--- a/developing.md
+++ b/developing.md
@@ -669,12 +669,15 @@ service coordination, release switching, health checks, or rollback.
 ### Server deployment
 
 A merge to `dev` does not deploy Superego. Maintainers use the runbook for the
-target environment.
+target environment. Superego owns private development data; Ego owns its
+independent public database after initialization.
 
-Do not merge or push any commit to `main`. Its active legacy self-hosted
-workflow can migrate and restart the public environment. Retire or disable it
-through a separate production change first, then verify the new boundary
-before using `main`.
+The legacy deployment workflows are disabled. Do not merge or push a public
+candidate to `main` until their self-hosted runners and deployment privileges
+are retired and the old deployment workflow is removed. After that boundary
+is verified, promote only a Git tree already deployed and validated on
+Superego, then build it independently on Ego under the protected public
+environment.
 
 Before deployment, decide which database contains the authoritative data. A
 disposable development target may be reset from a verified source snapshot. A

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "matsci-sam",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@10.34.5",
   "scripts": {
     "dev": "next dev",
     "check-types": "next typegen && tsc --noEmit",
@@ -11,6 +12,7 @@
     "test:identifiers": "tsx scripts/test-public-identifiers.ts",
     "test:auth": "tsx scripts/test-auth-plumbing.ts",
     "test:interface": "tsx scripts/test-interface-state.ts",
+    "test:deployment": "tsx scripts/test-deployment-contract.ts",
     "auth:gmail": "tsx scripts/authorize-gmail-sender.ts",
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",

--- a/scripts/test-deployment-contract.ts
+++ b/scripts/test-deployment-contract.ts
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict"
+import { createHash } from "node:crypto"
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+const root = process.cwd()
+
+const read = (path: string) => readFileSync(resolve(root, path), "utf8")
+
+const parseAssignments = (path: string) => {
+  const result = new Map<string, string>()
+
+  for (const [index, rawLine] of read(path).split(/\r?\n/).entries()) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith("#")) continue
+
+    const separator = line.indexOf("=")
+    assert.notEqual(
+      separator,
+      -1,
+      `${path}:${index + 1} is not an assignment`
+    )
+    const key = line.slice(0, separator).trim()
+    let value = line.slice(separator + 1).trim()
+    assert.match(key, /^[A-Z][A-Z0-9_]*$/, `${path} has an unsafe key`)
+    assert(!result.has(key), `${path} repeats ${key}`)
+
+    if (
+      value.length >= 2 &&
+      ((value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'")))
+    ) {
+      value = value.slice(1, -1)
+    }
+    result.set(key, value)
+  }
+
+  return result
+}
+
+const local = parseAssignments(".env.example")
+const superego = parseAssignments("deploy/app.env.example")
+const ego = parseAssignments("deploy/ego/app.env.example")
+const versions = parseAssignments("deploy/runtime-versions.env")
+
+const sortedKeys = (values: Map<string, string>) =>
+  [...values.keys()].sort()
+
+assert.deepEqual(
+  sortedKeys(superego),
+  sortedKeys(local),
+  "Superego and local environment contracts differ"
+)
+assert.deepEqual(
+  sortedKeys(ego),
+  sortedKeys(local),
+  "Ego and local environment contracts differ"
+)
+
+assert.equal(
+  superego.get("NEXT_PUBLIC_SITE_URL"),
+  "https://superego.cci.drexel.edu"
+)
+assert.equal(
+  superego.get("GOOGLE_CALLBACK_URL"),
+  "https://superego.cci.drexel.edu/api/auth/callback"
+)
+assert.equal(ego.get("NEXT_PUBLIC_SITE_URL"), "https://ego.cci.drexel.edu")
+assert.equal(
+  ego.get("GOOGLE_CALLBACK_URL"),
+  "https://ego.cci.drexel.edu/api/auth/callback"
+)
+assert.equal(ego.get("SESSION_COOKIE_SECURE"), "true")
+assert.equal(ego.get("DEV_AUTH_ENABLED"), "false")
+
+for (const key of [
+  "GOOGLE_CLIENT_ID",
+  "GOOGLE_CLIENT_SECRET",
+  "SESSION_PASSWORD",
+  "AUTH_TOKEN_ENCRYPTION_KEY"
+]) {
+  assert.equal(ego.get(key), "", `Ego template must not contain ${key}`)
+}
+
+const expectedVersionKeys = [
+  "ARCHITECTURE",
+  "NGINX_PACKAGE_VERSION",
+  "NODE_PACKAGE_VERSION",
+  "NODE_VERSION",
+  "PGVECTOR_PACKAGE_VERSION",
+  "PNPM_VERSION",
+  "POSTGRES_COMMON_PACKAGE_VERSION",
+  "POSTGRES_MAJOR",
+  "POSTGRES_PACKAGE_VERSION",
+  "UBUNTU_VERSION"
+].sort()
+assert.deepEqual(sortedKeys(versions), expectedVersionKeys)
+
+const packageJson = JSON.parse(read("package.json")) as {
+  packageManager?: string
+}
+assert.equal(
+  packageJson.packageManager,
+  `pnpm@${versions.get("PNPM_VERSION")}`,
+  "packageManager and the runtime contract differ"
+)
+
+const service = read("deploy/systemd/matsci-sam.service")
+assert.match(
+  service,
+  /^ExecStart=\/usr\/bin\/pnpm exec next start --hostname 127\.0\.0\.1 --port 3000$/m
+)
+
+const healthRoute = read("app/api/health/route.ts")
+assert.match(healthRoute, /drizzle\."__drizzle_migrations"/)
+for (const table of ['"users"', '"terms"', '"definitions"']) {
+  assert(healthRoute.includes(table), `Health readiness does not check ${table}`)
+}
+
+const localProxy = read(
+  "deploy/nginx/matsci-sam-public-local-ready.conf"
+)
+assert.match(localProxy, /server 127\.0\.0\.1:3000;/)
+assert(!localProxy.includes("10.246.250.19"))
+assert(!localProxy.includes("superego.cci.drexel.edu"))
+
+const superegoBootstrap = read(
+  "deploy/nginx/matsci-sam-superego.conf"
+)
+assert.match(superegoBootstrap, /server_name superego\.cci\.drexel\.edu;/)
+assert(!superegoBootstrap.includes("server_name ego.cci.drexel.edu"))
+assert(!superegoBootstrap.includes("129.25.202.67"))
+
+const maintenance = read(
+  "deploy/nginx/matsci-sam-public-maintenance.conf"
+)
+const maintenanceHash = createHash("sha256")
+  .update(maintenance)
+  .digest("hex")
+assert.equal(
+  maintenanceHash,
+  "3a569089e44265314a3cba59237b2619940960543d6f609343d7bf2973d4a4a8",
+  "The known-good Ego maintenance configuration changed"
+)
+
+console.log("Deployment contract checks passed.")


### PR DESCRIPTION
## What changed

- adds a one-command PA90 provisioner for an independent Ego Node.js, pnpm,
  PostgreSQL 17, pgvector, systemd, and local-loopback Nginx runtime
- pins the shared Superego/Ego runtime contract and adds non-secret parity
  diagnostics
- preserves Ego's active HTTPS maintenance contract, keeps the app disabled,
  creates only an empty socket-only database, and records the initial data
  authority as `uninitialized`
- retires the tracked Ego-to-Superego proxy topology and adds a disabled local
  application candidate
- adds schema-aware `/api/health` readiness and CI deployment-contract checks
- reconciles public/development deployment guidance and marks legacy
  workflows disabled but not yet fully retired

## Why

Ego needs to become an independently deployable public environment without
coupling its releases, secrets, or public data to the Superego development
server. The operator experience remains one supervised command, while the
wrapper validates source, authority, host/runtime, recovery state, package
signatures, database ownership, listeners, Nginx, and rollback boundaries.

## Safety boundary

This PR provisions prerequisites only. It does not seed data, install OAuth
credentials, deploy an application release, enable the app service, reload
Nginx, or cut over the public site. Ego remains in maintenance mode.

## Validation

- `pnpm check-types`
- `pnpm lint` (two pre-existing React Compiler compatibility warnings; no
  errors)
- `pnpm test:auth`
- `pnpm test:identifiers`
- `pnpm test:interface`
- `pnpm test:deployment`
- `pnpm db:check`
- `pnpm build`
- shell syntax checks for all deployment scripts
- live `check-runtime-parity.sh --allow-unprovisioned-ego`
- independent high-risk provisioning review
