### PR TITLE
Fix Ego pnpm service permissions

### DIFF
--- a/deploy/bootstrap-server.sh
+++ b/deploy/bootstrap-server.sh
@@ -135,7 +135,15 @@ EOF
 
 apt-get update
 apt-get install -y "nodejs=${NODE_PACKAGE_VERSION}"
-npm install --global "pnpm@${PNPM_VERSION}"
+(
+  umask 0022
+  npm install --global "pnpm@${PNPM_VERSION}"
+)
+pnpm_package_dir=/usr/lib/node_modules/pnpm
+[[ -d ${pnpm_package_dir} && ! -L ${pnpm_package_dir} &&
+  $(stat -c '%U:%G' "${pnpm_package_dir}") == root:root ]] ||
+  { echo "The global pnpm package has unexpected metadata." >&2; exit 1; }
+chmod -R u=rwX,go=rX "${pnpm_package_dir}"
 
 echo "Creating the application service account and standard directories..."
 if ! getent group "${APP_GROUP}" >/dev/null; then
@@ -151,6 +159,9 @@ if ! id "${APP_USER}" >/dev/null 2>&1; then
     --shell /usr/sbin/nologin \
     "${APP_USER}"
 fi
+[[ $(runuser -u "${APP_USER}" -- /usr/bin/pnpm --version) == \
+  "${PNPM_VERSION}" ]] ||
+  { echo "The application service account cannot execute pnpm." >&2; exit 1; }
 
 install -d -o root -g "${APP_GROUP}" -m 2775 \
   "${APP_ROOT}" \

--- a/deploy/check-runtime-parity.sh
+++ b/deploy/check-runtime-parity.sh
@@ -190,11 +190,11 @@ installation_contract=$(
 )
 printf 'operations_sha256\t%s\n' "$(
   sed -n 's/^matsci-sam-ops=//p' <<<"${installation_contract}" |
-    head -n 1
+    sed -n '1p'
 )"
 printf 'sudoers_sha256\t%s\n' "$(
-  sed -n 's/^matsci-sam-ops.sudoers=//p' <<<"${installation_contract}" |
-    head -n 1
+  sed -n 's/^matsci-sam-ops=//p' <<<"${installation_contract}" |
+    sed -n '2p'
 )"
 for endpoint in root ready terms index; do
   case ${endpoint} in

--- a/deploy/lib/provision-ego-runtime-remote.sh
+++ b/deploy/lib/provision-ego-runtime-remote.sh
@@ -637,7 +637,15 @@ apt-get install -y \
   "postgresql-common=${versions[POSTGRES_COMMON_PACKAGE_VERSION]}" \
   "postgresql-${versions[POSTGRES_MAJOR]}=${versions[POSTGRES_PACKAGE_VERSION]}" \
   "postgresql-${versions[POSTGRES_MAJOR]}-pgvector=${versions[PGVECTOR_PACKAGE_VERSION]}"
-npm install --global "pnpm@${versions[PNPM_VERSION]}"
+(
+  umask 0022
+  npm install --global "pnpm@${versions[PNPM_VERSION]}"
+)
+pnpm_package_dir=/usr/lib/node_modules/pnpm
+[[ -d ${pnpm_package_dir} && ! -L ${pnpm_package_dir} &&
+  $(stat -c '%U:%G' "${pnpm_package_dir}") == root:root ]] ||
+  fail "The global pnpm package has unexpected metadata."
+chmod -R u=rwX,go=rX "${pnpm_package_dir}"
 
 [[ $(node --version) == "${versions[NODE_VERSION]}" ]] ||
   fail "Installed Node.js differs from the runtime contract."
@@ -671,6 +679,9 @@ fi
   $(getent passwd "${app_user}" | awk -F: '{print $6 ":" $7}') == \
     "${app_state}:/usr/sbin/nologin" ]] ||
   fail "The application service account differs from the reviewed contract."
+[[ $(runuser -u "${app_user}" -- /usr/bin/pnpm --version) == \
+  "${versions[PNPM_VERSION]}" ]] ||
+  fail "The application service account cannot execute the reviewed pnpm."
 install -d -o root -g "${app_group}" -m 2775 \
   "${app_root}" \
   "${app_root}/releases" \

--- a/scripts/test-deployment-contract.ts
+++ b/scripts/test-deployment-contract.ts
@@ -111,6 +111,13 @@ assert.match(
   /^ExecStart=\/usr\/bin\/pnpm exec next start --hostname 127\.0\.0\.1 --port 3000$/m
 )
 
+const egoProvisioner = read("deploy/lib/provision-ego-runtime-remote.sh")
+assert.match(egoProvisioner, /umask 0022\s+npm install --global/)
+assert.match(
+  egoProvisioner,
+  /runuser -u "\$\{app_user\}" -- \/usr\/bin\/pnpm --version/
+)
+
 const healthRoute = read("app/api/health/route.ts")
 assert.match(healthRoute, /drizzle\."__drizzle_migrations"/)
 for (const table of ['"users"', '"terms"', '"definitions"']) {


### PR DESCRIPTION
## What changed

- scopes npm's installation umask to `0022`
- normalizes the reviewed global pnpm package directory to executable,
  non-writable permissions for service users
- verifies pnpm by executing it as the `matsci-sam` account
- correctly distinguishes the diagnostic helper and sudo-policy hashes

## Why

The first Ego provisioning run inherited the provisioner's secret-safe
`0077` umask while installing pnpm. Root could execute pnpm, but the
application service account could not traverse its mode-`0700` package
directory. The application remains disabled, the database is empty, and Ego
is still in maintenance mode.

The reviewed provisioner is intentionally rerunnable while Ego authority is
`uninitialized`, so the same command repairs this safely without replacing
the database or changing Nginx.

## Validation

- shell syntax checks
- `pnpm test:deployment`
- `git diff --check`
- live parity confirms every Ego contract except the expected pre-repair pnpm
  execution check
- independent recovery-path review
