### PR TITLE
Fix Ego seed awk portability

### DIFF
--- a/deploy/lib/seed-ego-from-superego-remote.sh
+++ b/deploy/lib/seed-ego-from-superego-remote.sh
@@ -598,6 +598,11 @@ environment_contract=$(
       expected["ORCID_AUTH_ENABLED"] = "false"
       expected["EMAIL_AUTH_ENABLED"] = "false"
       expected["DEV_AUTH_ENABLED"] = "false"
+      required["GOOGLE_CLIENT_ID"] = 1
+      required["GOOGLE_CLIENT_SECRET"] = 1
+      required["GOOGLE_AUTH_ALLOWED_EMAILS"] = 1
+      required["SESSION_PASSWORD"] = 1
+      required["AUTH_TOKEN_ENCRYPTION_KEY"] = 1
     }
     /^[[:space:]]*#/ || /^[[:space:]]*$/ { next }
     {
@@ -609,13 +614,7 @@ environment_contract=$(
       sub(/^[[:space:]]*/, "", value)
       sub(/[[:space:]]*$/, "", value)
       if (key in expected && value != expected[key]) bad[key] = 1
-      if (
-        key == "GOOGLE_CLIENT_ID" ||
-        key == "GOOGLE_CLIENT_SECRET" ||
-        key == "GOOGLE_AUTH_ALLOWED_EMAILS" ||
-        key == "SESSION_PASSWORD" ||
-        key == "AUTH_TOKEN_ENCRYPTION_KEY"
-      ) {
+      if (key in required) {
         if (length(value) > 0) present[key]++
       }
     }
@@ -623,13 +622,7 @@ environment_contract=$(
       for (key in expected) {
         if (count[key] != 1 || bad[key]) print key
       }
-      required[1] = "GOOGLE_CLIENT_ID"
-      required[2] = "GOOGLE_CLIENT_SECRET"
-      required[3] = "GOOGLE_AUTH_ALLOWED_EMAILS"
-      required[4] = "SESSION_PASSWORD"
-      required[5] = "AUTH_TOKEN_ENCRYPTION_KEY"
-      for (i = 1; i <= 5; i++) {
-        key = required[i]
+      for (key in required) {
         if (count[key] != 1 || present[key] != 1) print key
       }
       if (count["DEV_AUTH_USERS"] != 0) print "DEV_AUTH_USERS"

--- a/deploy/seed-ego-from-superego.sh
+++ b/deploy/seed-ego-from-superego.sh
@@ -109,10 +109,7 @@ if [[ -e ${stage}/prepare-state.tsv || -L ${stage}/prepare-state.tsv ]]; then
     phase=$(
       awk -F '\t' '$1 == "phase" { count++; value = $2 }
         END {
-          if (
-            count == 1 &&
-            value == "awaiting-offhost"
-          ) print value
+          if (count == 1 && value == "awaiting-offhost") print value
           else print "ambiguous"
         }' \
         "${stage}/prepare-state.tsv"
@@ -282,9 +279,10 @@ git -C "${repo}" show "${public_commit}:lib/apis/ollama.ts" |
 
 superego_authority=$(
   ssh -o BatchMode=yes -o ConnectTimeout=8 superego \
-    'if [[ -f /home/cr625/superego-admin/DATA-AUTHORITY &&
-       ! -L /home/cr625/superego-admin/DATA-AUTHORITY ]]; then
-       sed -n "1p" /home/cr625/superego-admin/DATA-AUTHORITY
+    'marker=/home/cr625/superego-admin/DATA-AUTHORITY
+     if [[ -f ${marker} && ! -L ${marker} &&
+       $(stat -c "%U:%a" "${marker}") == cr625:600 ]]; then
+       sed -n "1p" "${marker}"
      else
        echo missing
      fi'

--- a/scripts/test-deployment-contract.ts
+++ b/scripts/test-deployment-contract.ts
@@ -159,6 +159,57 @@ const egoSeedInvariants = read(
   "deploy/lib/ego-public-seed-invariants.sql"
 )
 
+const seedEnvironmentProgram = egoSeedHelper.match(
+  /environment_contract=\$\(\s+awk -F= '\n([\s\S]*?)\n  ' \/etc\/matsci-sam\/app\.env \|/
+)
+assert(
+  seedEnvironmentProgram,
+  "Could not locate the Ego seed environment-contract awk program"
+)
+const seedEnvironmentOutput = execFileSync(
+  "mawk",
+  [
+    "-F=",
+    seedEnvironmentProgram[1],
+    resolve(root, "deploy/ego/app.env.example")
+  ],
+  { encoding: "utf8" }
+)
+  .trim()
+  .split("\n")
+  .filter(Boolean)
+  .sort()
+assert.deepEqual(seedEnvironmentOutput, [
+  "AUTH_TOKEN_ENCRYPTION_KEY",
+  "GOOGLE_AUTH_ALLOWED_EMAILS",
+  "GOOGLE_CLIENT_ID",
+  "GOOGLE_CLIENT_SECRET",
+  "SESSION_PASSWORD"
+])
+
+const seedCleanupProgram = egoSeedWrapper.match(
+  /phase=\$\(\s+awk -F '\\t' '([\s\S]*?)' \\\s+"\$\{stage\}\/prepare-state\.tsv"\s+\)/
+)
+assert(
+  seedCleanupProgram,
+  "Could not locate the Ego seed cleanup-state awk program"
+)
+const seedCleanupDirectory = mkdtempSync(
+  resolve(tmpdir(), "matsci-sam-seed-cleanup-")
+)
+const seedCleanupPath = resolve(seedCleanupDirectory, "prepare-state.tsv")
+writeFileSync(seedCleanupPath, "phase\tawaiting-offhost\n", { mode: 0o600 })
+try {
+  assert.equal(
+    execFileSync("mawk", ["-F", "\t", seedCleanupProgram[1], seedCleanupPath], {
+      encoding: "utf8"
+    }).trim(),
+    "awaiting-offhost"
+  )
+} finally {
+  rmSync(seedCleanupDirectory, { recursive: true, force: true })
+}
+
 assert.match(egoSeedWrapper, /EGO_SEED_CHAT_FALLBACK/)
 assert.match(
   egoSeedWrapper,
@@ -174,6 +225,10 @@ assert.match(egoSeedWrapper, /phase\\toffhost-verified/)
 assert.match(egoSeedWrapper, /ego_audit=/)
 assert.match(egoSeedWrapper, /Reusing the previously verified off-host seed backup/)
 assert.match(egoSeedWrapper, /existing off-host seed backup does not match/)
+assert.match(
+  egoSeedWrapper,
+  /stat -c "%U:%a" "\$\{marker\}"\) == cr625:600/
+)
 assert.match(
   egoSeedWrapper,
   /\/var\/lib\/matsci-sam-admin\/backups\/ego-initial-seed-/


### PR DESCRIPTION
## Summary

- make Ego seed environment validation portable to the mawk implementation installed on Ego
- fix the equivalent latent cleanup-state AWK construct
- verify the Superego authority marker ownership and mode before beginning the seed
- add deployment-contract regressions that execute both embedded programs with mawk

## Failure safety

The failed seed stopped before scratch or live database creation, privacy transforms, backups, or any authority transition. Ego remains empty and in maintenance; Superego remains authoritative and unchanged.

## Validation

- pnpm lint (zero errors; two existing React Compiler compatibility warnings)
- pnpm check-types
- pnpm test:auth
- pnpm test:identifiers
- pnpm test:interface
- pnpm test:ollama-context
- pnpm test:deployment
- pnpm db:check
- bash syntax checks for both seed scripts
- git diff --check