### PR TITLE
Fix Ego pgvector restores

### DIFF
--- a/deploy/lib/cutover-ego-public-remote.sh
+++ b/deploy/lib/cutover-ego-public-remote.sh
@@ -523,6 +523,15 @@ runuser -u postgres -- createdb \
   --owner=matsci-sam \
   "${scratch_database}"
 scratch_created=true
+runuser -u postgres -- psql \
+  --host=/var/run/postgresql \
+  --port=5432 \
+  --dbname="${scratch_database}" \
+  --set ON_ERROR_STOP=1 \
+  --command='CREATE EXTENSION IF NOT EXISTS vector' \
+  >/dev/null
+# Match the administrator-owned extension boundary verified during release
+# preparation and skip archive comments during the application-role restore.
 runuser -u matsci-sam -- pg_restore \
   --host=/var/run/postgresql \
   --port=5432 \
@@ -531,6 +540,7 @@ runuser -u matsci-sam -- pg_restore \
   --single-transaction \
   --no-owner \
   --no-privileges \
+  --no-comments \
   <"${database_backup}"
 restored_database_facts=$(database_facts "${scratch_database}")
 restored_database_facts_sha256=$(

--- a/deploy/lib/deploy-ego-precutover-remote.sh
+++ b/deploy/lib/deploy-ego-precutover-remote.sh
@@ -610,6 +610,15 @@ runuser -u postgres -- createdb \
   --owner=matsci-sam \
   "${scratch_database}"
 scratch_created=true
+runuser -u postgres -- psql \
+  --host=/var/run/postgresql \
+  --port=5432 \
+  --dbname="${scratch_database}" \
+  --set ON_ERROR_STOP=1 \
+  --command='CREATE EXTENSION IF NOT EXISTS vector' \
+  >/dev/null
+# The extension stays administrator-owned; application data restores do not
+# replay archive comments against it.
 runuser -u matsci-sam -- pg_restore \
   --host=/var/run/postgresql \
   --port=5432 \
@@ -618,6 +627,7 @@ runuser -u matsci-sam -- pg_restore \
   --single-transaction \
   --no-owner \
   --no-privileges \
+  --no-comments \
   <"${backup_partial}"
 [[ $(database_facts "${scratch_database}") == "${live_facts}" ]] ||
   fail "The restored backup differs from the seeded Ego database."

--- a/deploy/lib/export-superego-for-ego-seed-remote.sh
+++ b/deploy/lib/export-superego-for-ego-seed-remote.sh
@@ -269,6 +269,8 @@ runuser -u postgres -- psql \
   --command='CREATE EXTENSION IF NOT EXISTS vector' \
   >/dev/null
 assert_pgvector "${check_database}"
+# Keep an administrator-owned extension immutable during an application-role
+# restore, including when a future source archive carries its default comment.
 runuser -u "${app_user}" -- pg_restore \
   --host=/var/run/postgresql \
   --port=5432 \
@@ -277,6 +279,7 @@ runuser -u "${app_user}" -- pg_restore \
   --single-transaction \
   --no-owner \
   --no-privileges \
+  --no-comments \
   <"${dump}"
 assert_pgvector "${check_database}"
 runuser -u "${app_user}" -- psql \

--- a/deploy/lib/seed-ego-from-superego-remote.sh
+++ b/deploy/lib/seed-ego-from-superego-remote.sh
@@ -92,6 +92,9 @@ assert_pgvector() {
 restore_dump() {
   local name=$1
   local dump=$2
+  # pgvector is deliberately installed by postgres. A dump made from that
+  # database can contain COMMENT ON EXTENSION vector, which the application
+  # role must not own or alter.
   runuser -u "${app_user}" -- pg_restore \
     --host=/var/run/postgresql \
     --port=5432 \
@@ -100,6 +103,7 @@ restore_dump() {
     --single-transaction \
     --no-owner \
     --no-privileges \
+    --no-comments \
     <"${dump}"
 }
 

--- a/scripts/test-deployment-contract.ts
+++ b/scripts/test-deployment-contract.ts
@@ -269,6 +269,14 @@ assert.match(
   /install -o root -g root -m 0400[\s\S]*"\$\{stage\}\/\$\{staged_file\}"[\s\S]*"\$\{input_dir\}\/\$\{staged_file\}"/
 )
 assert.match(egoSeedExportHelper, /CREATE EXTENSION IF NOT EXISTS vector/)
+assert.match(
+  egoSeedExportHelper,
+  /CREATE EXTENSION IF NOT EXISTS vector[\s\S]*pg_restore[\s\S]*--no-comments[\s\S]*<"\$\{dump\}"/
+)
+assert.match(
+  egoSeedHelper,
+  /restore_dump\(\)[\s\S]*pg_restore[\s\S]*--no-comments[\s\S]*<"\$\{dump\}"/
+)
 
 const transformIndex = egoSeedHelper.indexOf(
   'echo "Applying the reviewed public privacy transformation."'
@@ -454,7 +462,7 @@ assert.match(
 assert.match(egoReleaseRemote, /pg_dump[\s\S]*--format=custom/)
 assert.match(
   egoReleaseRemote,
-  /pg_restore[\s\S]*--dbname="\$\{scratch_database\}"/
+  /createdb[\s\S]*CREATE EXTENSION IF NOT EXISTS vector[\s\S]*pg_restore[\s\S]*--dbname="\$\{scratch_database\}"[\s\S]*--no-comments[\s\S]*<"\$\{backup_partial\}"/
 )
 assert.match(
   egoReleaseRemote,
@@ -568,7 +576,7 @@ assert.match(
 )
 assert.match(
   egoCutoverRemote,
-  /pg_restore[\s\S]*--dbname="\$\{scratch_database\}"[\s\S]*<"\$\{database_backup\}"/
+  /createdb[\s\S]*CREATE EXTENSION IF NOT EXISTS vector[\s\S]*pg_restore[\s\S]*--dbname="\$\{scratch_database\}"[\s\S]*--no-comments[\s\S]*<"\$\{database_backup\}"/
 )
 assert.match(
   egoCutoverRemote,


### PR DESCRIPTION
## Summary

- keep pgvector administrator-owned in Ego scratch databases
- skip archive comments when restoring as the application role
- apply the same contract to the one-time seed, Superego export rehearsal, first-release backup rehearsal, and final cutover rehearsal
- add deployment-contract checks for extension creation order and restore flags

## Root cause

Ego creates the vector extension as postgres. PostgreSQL 17 includes COMMENT ON EXTENSION vector in the sanitized archive, but the second restore runs as matsci-sam. Neither --no-owner nor --no-privileges suppresses comments, so PostgreSQL correctly rejected the attempted comment by a non-owner. The restore is single-transaction and failed before live database mutation or authority transition.

## Safety

Ego remains empty, uninitialized, inactive, and in HTTPS maintenance. Superego remains healthy and authoritative. No off-host seed backup was created by the failed attempt.

## Validation

- pnpm test:deployment
- bash syntax checks for all four changed deployment helpers
- pnpm lint (zero errors; two existing React Compiler compatibility warnings)
- pnpm check-types under Node 24.18.0
- authentication, identifier, interface, and Ollama-context tests
- pnpm db:check
- verified that application migrations contain no COMMENT ON statements
- git diff --check