### PR TITLE
Harden Ego deployment source validation and register Area51

### DIFF
--- a/.agents/skills/manage-matsci-environments/SKILL.md
+++ b/.agents/skills/manage-matsci-environments/SKILL.md
@@ -29,9 +29,12 @@ Those facts change too often.
 - `origin/dev` owns reviewed source. Exactly one recorded control workstation
   owns builds, tests, migrations, release preparation, private documentation,
   and deployment initiation.
-- A public candidate must use a Git tree already deployed and verified on
-  Superego. Promote that tree to `origin/main`, then build it again under the
-  protected Ego environment.
+- A public candidate must keep reviewed `origin/dev` and promoted
+  `origin/main` on the same exact tree. Its application, schema, migration,
+  dependency, build, service, and runtime-configuration content must already
+  be deployed and verified on Superego. A reviewed public-operations change
+  may differ only through the exact fail-closed allowlist enforced by
+  `deploy/lib/verify-superego-public-content.sh`.
 - A workstation must be explicitly registered before it can deploy or receive
   a shared-data snapshot. The reviewed registry is
   `deploy/workstations.tsv`; the state file separately selects the sole
@@ -126,8 +129,9 @@ After the seed, prepare Ego's first release without changing the public edge:
 ./deploy/deploy-ego-from-workstation.sh
 ```
 
-This first-release wrapper requires the same tree on reviewed `dev`,
-Superego, and promoted `main`. It leaves Nginx in maintenance. Public
+This first-release wrapper requires the same exact tree on reviewed `dev` and
+promoted `main`, plus application content already validated on Superego under
+the reviewed non-runtime allowlist. It leaves Nginx in maintenance. Public
 activation is a separate supervised operation:
 
 ```bash

--- a/.agents/skills/manage-matsci-environments/references/environments.md
+++ b/.agents/skills/manage-matsci-environments/references/environments.md
@@ -11,8 +11,7 @@ copied state file.
 - Repository: `/home/chris/systemada/dev/matsci-yamz`
 - Private documentation:
   `/mnt/d/OneDrive/Working/Matsci/docs-internal`
-- Role: current control-workstation candidate, builds, tests, release
-  preparation, and local preview
+- Role: registered development workstation
 
 The repository path `docs-internal` is a symlink to the D-drive OneDrive
 directory.
@@ -22,11 +21,12 @@ not this registry, identifies the active control workstation.
 
 ## Area51
 
-- Role: planned standby development and local-inference workstation
+- Host: `Area51`
+- Repository: `/home/chris/systemada/dev/matsci-yamz`
+- Private documentation:
+  `/mnt/c/Users/Chris/OneDrive/Working/Matsci/docs-internal`
+- Role: registered development and local-inference workstation
 
-Do not invent its hostname, paths, database role, or SSH configuration. Verify
-those facts during onboarding before adding it to
-`deploy/workstations.tsv`.
 Running an LLM does not grant source, release, or data authority.
 
 ## Superego
@@ -81,11 +81,12 @@ The Ego authority marker is
 runtime provisioning and changes to `ego` after the reviewed one-time seed.
 Never replace or refresh the database from Superego after that transition.
 
-Ego does not own a source-editing workspace. Public source is a reviewed tree
-validated on Superego, promoted to `origin/main`, and deployed from the control
-workstation. Inspect the complete effective Nginx configuration, preserve a
-known-good backup, validate with `nginx -t`, and verify the public endpoint
-contract before and after a reload.
+Ego does not own a source-editing workspace. Public `origin/main` must exactly
+match reviewed `origin/dev`. Application content must already be validated on
+Superego; only the exact reviewed non-runtime allowlist may differ. Deployment
+originates on the recorded control workstation. Inspect the complete effective
+Nginx configuration, preserve a known-good backup, validate with `nginx -t`,
+and verify the public endpoint contract before and after a reload.
 
 ## Legacy production
 

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -68,6 +68,7 @@ jobs:
             deploy/lib/seed-ego-from-superego-remote.sh \
             deploy/lib/deploy-ego-precutover-remote.sh \
             deploy/lib/cutover-ego-public-remote.sh \
+            deploy/lib/verify-superego-public-content.sh \
             deploy/ops/matsci-sam-ops \
             .agents/skills/manage-matsci-environments/scripts/status.sh
 

--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@ Private environment policy remains in `docs-internal`.
 The legacy production workflows are disabled. Do not merge or push a public
 candidate to `main` until their self-hosted runners and deployment privileges
 have also been retired and the old deployment workflow has been removed.
-After that boundary is verified, the intended public path promotes a tree
-already validated on Superego from `dev` to `main` and builds it independently
-on Ego.
+After that boundary is verified, the intended public path keeps reviewed
+`dev` and promoted `main` on the same exact tree, requires its application
+content to match the release validated on Superego, and builds it independently
+on Ego. Only an exact reviewed non-runtime operations allowlist may differ from
+the Superego release.
 
 ## Project structure
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -105,9 +105,11 @@ conversation records must not become public by accident. A successful seed
 changes the Ego authority marker from `uninitialized` to `ego`. After that
 change, never replace or refresh the Ego database from Superego.
 
-Configure and validate the separate public OAuth client first. Then, after the
-exact promoted tree is running on Superego, run the seed in a supervised
-foreground terminal:
+Configure and validate the public OAuth client first. Then, after the promoted
+application content is verified on Superego, run the seed in a supervised
+foreground terminal. Reviewed public-operation changes may differ only through
+the exact fail-closed allowlist in
+`deploy/lib/verify-superego-public-content.sh`:
 
 ```bash
 ./deploy/seed-ego-from-superego.sh --check-only
@@ -182,12 +184,15 @@ The release path is:
 
 ```text
 reviewed origin/dev -> Superego validation
-identical reviewed tree -> origin/main -> Ego
+exact reviewed dev tree -> origin/main -> Ego
 ```
 
 The main commit may differ from the validated dev commit when GitHub creates a
-merge commit. The application tree and migration tree must match. Ego builds
-that tree again with the public environment because
+merge commit. `origin/main` and `origin/dev` must have the same exact tree.
+Application, schema, migration, dependency, build, service, and runtime
+configuration content must match the Superego-validated release; only the
+explicit reviewed non-runtime allowlist may differ. Ego builds the promoted
+tree again with the public environment because
 `NEXT_PUBLIC_SITE_URL` is build-time configuration.
 
 When both authority records identify Superego as the shared-data authority,

--- a/deploy/cutover-ego-public.sh
+++ b/deploy/cutover-ego-public.sh
@@ -4,10 +4,29 @@ set -Eeuo pipefail
 
 umask 0077
 export GIT_NO_REPLACE_OBJECTS=1
+unset \
+  GIT_ALTERNATE_OBJECT_DIRECTORIES \
+  GIT_COMMON_DIR \
+  GIT_CONFIG_COUNT \
+  GIT_CONFIG_PARAMETERS \
+  GIT_DEFAULT_HASH \
+  GIT_DEFAULT_REF_FORMAT \
+  GIT_DIR \
+  GIT_GLOB_PATHSPECS \
+  GIT_ICASE_PATHSPECS \
+  GIT_INDEX_FILE \
+  GIT_LITERAL_PATHSPECS \
+  GIT_NOGLOB_PATHSPECS \
+  GIT_NAMESPACE \
+  GIT_OBJECT_DIRECTORY \
+  GIT_SHALLOW_FILE \
+  GIT_TEMPLATE_DIR \
+  GIT_WORK_TREE
 
 script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 repo=$(cd -- "${script_dir}/.." && pwd)
 remote_helper=${script_dir}/lib/cutover-ego-public-remote.sh
+superego_content_verifier=${script_dir}/lib/verify-superego-public-content.sh
 maintenance_config=${script_dir}/nginx/matsci-sam-public-maintenance.conf
 local_candidate=${script_dir}/nginx/matsci-sam-public-local-ready.conf
 state_file=${repo}/docs-internal/CURRENT-DEV-STATE.md
@@ -41,6 +60,39 @@ USAGE
 fail() {
   echo "$*" >&2
   exit 1
+}
+
+verify_reviewed_worktree() {
+  local commit=$1
+  local helper_path=deploy/lib/verify-superego-public-content.sh
+  local helper_entry
+  local helper_mode
+  local helper_type
+  local expected_hash
+  local entry_path
+  local actual_hash
+
+  helper_entry=$(git -C "${repo}" ls-tree "${commit}" -- "${helper_path}")
+  [[ -n ${helper_entry} && ${helper_entry} != *$'\n'* ]] ||
+    fail "The reviewed source does not uniquely identify the content verifier."
+  read -r helper_mode helper_type expected_hash entry_path <<<"${helper_entry}"
+  [[ ${helper_mode} == 100755 &&
+    ${helper_type} == blob &&
+    ${expected_hash} =~ ^[0-9a-f]{40}$ &&
+    ${entry_path} == "${helper_path}" &&
+    -f ${superego_content_verifier} &&
+    ! -L ${superego_content_verifier} &&
+    -x ${superego_content_verifier} ]] ||
+    fail "The reviewed content verifier contract is invalid."
+  actual_hash=$(
+    git -C "${repo}" hash-object \
+      --no-filters \
+      -- "${superego_content_verifier}"
+  )
+  [[ ${actual_hash} == "${expected_hash}" ]] ||
+    fail "The executed content verifier differs from reviewed source."
+  "${superego_content_verifier}" --verify-worktree "${repo}" "${commit}" ||
+    fail "The raw worktree does not match reviewed source."
 }
 
 cleanup() {
@@ -89,6 +141,7 @@ done
 
 for file in \
   "${remote_helper}" \
+  "${superego_content_verifier}" \
   "${maintenance_config}" \
   "${local_candidate}" \
   "${state_file}" \
@@ -157,6 +210,7 @@ dev_tree=$(git -C "${repo}" rev-parse "${origin_dev}^{tree}")
   fail "The promoted public source ref is invalid."
 [[ ${dev_tree} == "${expected_tree}" ]] ||
   fail "origin/main is not the exact reviewed origin/dev tree."
+verify_reviewed_worktree "${expected_commit}"
 
 maintenance_sha=$(sha256sum "${maintenance_config}" | awk '{print $1}')
 candidate_sha=$(sha256sum "${local_candidate}" | awk '{print $1}')
@@ -233,6 +287,21 @@ printf 'Type CUT OVER EGO PUBLIC to continue: '
 IFS= read -r confirmation
 [[ ${confirmation} == "CUT OVER EGO PUBLIC" ]] ||
   fail "Public cutover cancelled."
+
+git -C "${repo}" fetch --prune origin dev main
+[[ -z $(git -C "${repo}" status --porcelain=v1) &&
+  $(git -C "${repo}" rev-parse HEAD) == "${origin_dev}" &&
+  $(git -C "${repo}" rev-parse refs/remotes/origin/dev) == "${origin_dev}" &&
+  $(git -C "${repo}" rev-parse refs/remotes/origin/main) == "${expected_commit}" &&
+  $(git -C "${repo}" rev-parse "${expected_commit}^{tree}") == "${expected_tree}" ]] ||
+  fail "Reviewed source changed during the public-cutover checks."
+verify_reviewed_worktree "${expected_commit}"
+[[ $(sha256sum "${maintenance_config}" | awk '{print $1}') == \
+  "${maintenance_sha}" &&
+  $(sha256sum "${local_candidate}" | awk '{print $1}') == \
+  "${candidate_sha}" &&
+  $(sha256sum "${remote_helper}" | awk '{print $1}') == "${helper_sha}" ]] ||
+  fail "A reviewed cutover input changed during the public-cutover checks."
 
 stamp=$(date -u +%Y%m%dT%H%M%SZ)
 remote_dir="/home/cr625/ego-admin/incoming/public-cutover-${expected_commit:0:12}-${stamp}"

--- a/deploy/cutover-ego-public.sh
+++ b/deploy/cutover-ego-public.sh
@@ -3,6 +3,7 @@
 set -Eeuo pipefail
 
 umask 0077
+export GIT_NO_REPLACE_OBJECTS=1
 
 script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 repo=$(cd -- "${script_dir}/.." && pwd)
@@ -254,6 +255,8 @@ manifest=$(mktemp)
   printf 'helper_sha256\t%s\n' "${helper_sha}"
   printf 'maintenance_sha256\t%s\n' "${maintenance_sha}"
   printf 'candidate_sha256\t%s\n' "${candidate_sha}"
+  printf 'workstation_registry_sha256\t%s\n' \
+    "$(sha256sum "${workstation_registry}" | awk '{print $1}')"
 } >"${manifest}"
 
 scp "${manifest}" "ego:${remote_dir}/manifest"
@@ -261,13 +264,15 @@ scp \
   "${remote_helper}" \
   "${maintenance_config}" \
   "${local_candidate}" \
+  "${workstation_registry}" \
   "ego:${remote_dir}/"
 ssh ego \
   "chmod 0600 \
      '${remote_dir}/manifest' \
      '${remote_dir}/cutover-ego-public-remote.sh' \
      '${remote_dir}/matsci-sam-public-maintenance.conf' \
-     '${remote_dir}/matsci-sam-public-local-ready.conf'"
+     '${remote_dir}/matsci-sam-public-local-ready.conf' \
+     '${remote_dir}/workstations.tsv'"
 rm -f "${manifest}"
 manifest=
 

--- a/deploy/deploy-ego-from-workstation.sh
+++ b/deploy/deploy-ego-from-workstation.sh
@@ -2,6 +2,7 @@
 set -Eeuo pipefail
 
 umask 0077
+export GIT_NO_REPLACE_OBJECTS=1
 
 script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 repo=$(cd -- "${script_dir}/.." && pwd)
@@ -9,6 +10,7 @@ remote_helper=${script_dir}/lib/deploy-ego-precutover-remote.sh
 invariants=${script_dir}/lib/reset-db-invariants.sql
 seed_invariants=${script_dir}/lib/ego-public-seed-invariants.sql
 ledger_verifier=${script_dir}/lib/verify-migration-ledger.sh
+superego_content_verifier=${script_dir}/lib/verify-superego-public-content.sh
 maintenance_config=${script_dir}/nginx/matsci-sam-public-maintenance.conf
 local_candidate=${script_dir}/nginx/matsci-sam-public-local-ready.conf
 state_file=${repo}/docs-internal/CURRENT-DEV-STATE.md
@@ -94,7 +96,7 @@ done
 
 for file in "${remote_helper}" "${invariants}" "${seed_invariants}" \
   "${ledger_verifier}" "${maintenance_config}" "${local_candidate}" \
-  "${state_file}" "${workstation_registry}"
+  "${superego_content_verifier}" "${state_file}" "${workstation_registry}"
 do
   [[ -f ${file} && ! -L ${file} ]] ||
     fail "Required deployment file is missing or unsafe: ${file}"
@@ -180,8 +182,12 @@ superego_commit=${superego_name:0:40}
 git -C "${repo}" cat-file -e "${superego_commit}^{commit}" 2>/dev/null ||
   fail "The active Superego commit is not present in local Git history."
 superego_tree=$(git -C "${repo}" rev-parse "${superego_commit}^{tree}")
-[[ ${candidate_tree} == "${superego_tree}" ]] ||
-  fail "origin/main is not the exact tree currently validated on Superego."
+superego_validation=$(
+  "${superego_content_verifier}" \
+    "${repo}" \
+    "${superego_commit}" \
+    "${candidate}"
+) || fail "The public application content is not the content validated on Superego."
 
 ego_release_state=$(
   ssh -o BatchMode=yes ego '
@@ -227,8 +233,11 @@ fi
 work_dir=$(mktemp -d)
 archive=${work_dir}/source.tar
 manifest=${work_dir}/manifest.tsv
-git -C "${repo}" archive --format=tar "${candidate}" >"${archive}"
-tar --list --file="${archive}" >/dev/null
+"${superego_content_verifier}" \
+  --create-archive \
+  "${repo}" \
+  "${candidate}" \
+  "${archive}"
 archive_sha=$(sha256sum "${archive}" | awk '{print $1}')
 
 {
@@ -246,6 +255,9 @@ archive_sha=$(sha256sum "${archive}" | awk '{print $1}')
 
 printf 'Validated Ego pre-cutover artifact for origin/main commit %s.\n' \
   "${candidate}"
+printf 'validated_superego_commit=%s\n' "${superego_commit}"
+printf 'validated_superego_tree=%s\n' "${superego_tree}"
+printf 'superego_validation=%s\n' "${superego_validation}"
 if [[ ${check_only} == true ]]; then
   echo "Ego pre-cutover artifact validation passed."
   exit 0

--- a/deploy/deploy-ego-from-workstation.sh
+++ b/deploy/deploy-ego-from-workstation.sh
@@ -3,6 +3,24 @@ set -Eeuo pipefail
 
 umask 0077
 export GIT_NO_REPLACE_OBJECTS=1
+unset \
+  GIT_ALTERNATE_OBJECT_DIRECTORIES \
+  GIT_COMMON_DIR \
+  GIT_CONFIG_COUNT \
+  GIT_CONFIG_PARAMETERS \
+  GIT_DEFAULT_HASH \
+  GIT_DEFAULT_REF_FORMAT \
+  GIT_DIR \
+  GIT_GLOB_PATHSPECS \
+  GIT_ICASE_PATHSPECS \
+  GIT_INDEX_FILE \
+  GIT_LITERAL_PATHSPECS \
+  GIT_NOGLOB_PATHSPECS \
+  GIT_NAMESPACE \
+  GIT_OBJECT_DIRECTORY \
+  GIT_SHALLOW_FILE \
+  GIT_TEMPLATE_DIR \
+  GIT_WORK_TREE
 
 script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 repo=$(cd -- "${script_dir}/.." && pwd)
@@ -42,6 +60,39 @@ USAGE
 fail() {
   echo "$*" >&2
   exit 1
+}
+
+verify_reviewed_worktree() {
+  local commit=$1
+  local helper_path=deploy/lib/verify-superego-public-content.sh
+  local helper_entry
+  local helper_mode
+  local helper_type
+  local expected_hash
+  local entry_path
+  local actual_hash
+
+  helper_entry=$(git -C "${repo}" ls-tree "${commit}" -- "${helper_path}")
+  [[ -n ${helper_entry} && ${helper_entry} != *$'\n'* ]] ||
+    fail "The reviewed source does not uniquely identify the content verifier."
+  read -r helper_mode helper_type expected_hash entry_path <<<"${helper_entry}"
+  [[ ${helper_mode} == 100755 &&
+    ${helper_type} == blob &&
+    ${expected_hash} =~ ^[0-9a-f]{40}$ &&
+    ${entry_path} == "${helper_path}" &&
+    -f ${superego_content_verifier} &&
+    ! -L ${superego_content_verifier} &&
+    -x ${superego_content_verifier} ]] ||
+    fail "The reviewed content verifier contract is invalid."
+  actual_hash=$(
+    git -C "${repo}" hash-object \
+      --no-filters \
+      -- "${superego_content_verifier}"
+  )
+  [[ ${actual_hash} == "${expected_hash}" ]] ||
+    fail "The executed content verifier differs from reviewed source."
+  "${superego_content_verifier}" --verify-worktree "${repo}" "${commit}" ||
+    fail "The raw worktree does not match reviewed source."
 }
 
 cleanup() {
@@ -168,6 +219,7 @@ candidate_tree=$(git -C "${repo}" rev-parse "${candidate}^{tree}")
 dev_tree=$(git -C "${repo}" rev-parse "${origin_dev}^{tree}")
 [[ ${candidate_tree} == "${dev_tree}" ]] ||
   fail "origin/main does not contain the exact reviewed origin/dev tree."
+verify_reviewed_worktree "${candidate}"
 
 superego_release=$(
   ssh -o BatchMode=yes superego \
@@ -229,6 +281,7 @@ fi
   fail "A reviewed source ref changed during deployment preparation."
 [[ $(git -C "${repo}" rev-parse "${candidate}^{tree}") == "${candidate_tree}" ]] ||
   fail "The promoted public tree changed during deployment preparation."
+verify_reviewed_worktree "${candidate}"
 
 work_dir=$(mktemp -d)
 archive=${work_dir}/source.tar

--- a/deploy/ego/AGENTS.md
+++ b/deploy/ego/AGENTS.md
@@ -10,8 +10,8 @@ at `ego.cci.drexel.edu`.
 - A reviewed tree promoted to `origin/main` is the public release source.
 - Ego owns its public TLS, Nginx, application releases, protected
   configuration, and PostgreSQL database.
-- PA90 is the control workstation for tests, release preparation, and
-  deployment initiation.
+- The sole control workstation recorded in `CURRENT-DEV-STATE.md` owns tests,
+  release preparation, and deployment initiation.
 
 Run `$manage-matsci-environments` and inspect live state before acting.
 
@@ -28,8 +28,10 @@ Run `$manage-matsci-environments` and inspect live state before acting.
 - Run the one-time seed, first pre-cutover release, and public cutover only
   from the recorded control workstation. Do not invoke files under
   `deploy/lib/` directly.
-- A public candidate must use the exact Git tree already deployed and verified
-  on Superego, then promoted to `origin/main`.
+- Promoted `origin/main` must exactly match reviewed `origin/dev`. Application,
+  schema, migration, dependency, build, service, and runtime-configuration
+  content must already be validated on Superego; only the exact reviewed
+  non-runtime allowlist may differ.
 - `deploy/deploy-ego-from-workstation.sh` prepares only the first release
   after the seed. It verifies the Ego-authoritative database, builds under the
   protected public environment, starts the application on loopback, and keeps
@@ -49,5 +51,6 @@ Run `$manage-matsci-environments` and inspect live state before acting.
   cancelled operation.
 - Do not create a source worktree or copied rolling-state document here.
 
-Exact commits, releases, database facts, and data-authority state are recorded
-only in `docs-internal/CURRENT-DEV-STATE.md` on PA90.
+Exact commits, releases, database facts, control-workstation identity, and
+data-authority state are recorded only in
+`docs-internal/CURRENT-DEV-STATE.md` on the control workstation.

--- a/deploy/lib/cutover-ego-public-remote.sh
+++ b/deploy/lib/cutover-ego-public-remote.sh
@@ -286,7 +286,8 @@ expected_stage_files=$(
     cutover-ego-public-remote.sh \
     manifest \
     matsci-sam-public-local-ready.conf \
-    matsci-sam-public-maintenance.conf |
+    matsci-sam-public-maintenance.conf \
+    workstations.tsv |
     sort
 )
 actual_stage_files=$(
@@ -337,6 +338,7 @@ manifest_keys=(
   helper_sha256
   maintenance_sha256
   candidate_sha256
+  workstation_registry_sha256
 )
 is_manifest_key() {
   local candidate=$1
@@ -360,14 +362,17 @@ for key in "${manifest_keys[@]}"; do
   [[ -v "manifest[${key}]" ]] ||
     fail "The cutover manifest is incomplete."
 done
-[[ ${manifest[format]} == 1 && ${manifest[source_host]} == pa90 ]] ||
+[[ ${manifest[format]} == 1 &&
+  ${manifest[source_host]} =~ ^[a-z][a-z0-9-]*$ ]] ||
   fail "The cutover manifest has an invalid source contract."
 [[ ${manifest[expected_commit]} =~ ^[0-9a-f]{40}$ &&
   ${manifest[expected_tree]} =~ ^[0-9a-f]{40}$ ]] ||
   fail "The cutover manifest has an invalid release identity."
 [[ ${manifest[expected_release]} =~ ^/opt/matsci-sam/releases/${manifest[expected_commit]}-[A-Za-z0-9]{8}$ ]] ||
   fail "The cutover manifest has an invalid release path."
-for key in helper_sha256 maintenance_sha256 candidate_sha256; do
+for key in helper_sha256 maintenance_sha256 candidate_sha256 \
+  workstation_registry_sha256
+do
   [[ ${manifest[${key}]} =~ ^[0-9a-f]{64}$ ]] ||
     fail "The cutover manifest has an invalid file hash."
 done
@@ -380,6 +385,23 @@ done
 [[ $(sha256sum "${stage}/matsci-sam-public-local-ready.conf" |
   awk '{print $1}') == "${manifest[candidate_sha256]}" ]] ||
   fail "The staged local candidate hash is invalid."
+[[ $(sha256sum "${stage}/workstations.tsv" | awk '{print $1}') == \
+  "${manifest[workstation_registry_sha256]}" ]] ||
+  fail "The staged workstation registry hash is invalid."
+
+registered_source=$(
+  awk -F '\t' -v source="${manifest[source_host]}" '
+    /^#/ || /^[[:space:]]*$/ { next }
+    NF != 3 { exit 2 }
+    $1 !~ /^[a-z][a-z0-9-]*$/ { exit 2 }
+    $2 !~ /^[A-Za-z0-9][A-Za-z0-9.-]*$/ { exit 2 }
+    $3 != "yes" && $3 != "no" { exit 2 }
+    ++seen_id[$1] > 1 || ++seen_host[$2] > 1 { exit 2 }
+    $1 == source { print $0 }
+  ' "${stage}/workstations.tsv"
+) || fail "The staged workstation registry is malformed."
+[[ -n ${registered_source} && ${registered_source} != *$'\n'* ]] ||
+  fail "The source workstation is not uniquely registered."
 
 [[ -f ${authority_file} && ! -L ${authority_file} &&
   $(stat -c '%U:%a' "${authority_file}") == cr625:600 &&
@@ -389,6 +411,10 @@ release=$(readlink -e /opt/matsci-sam/current) ||
   fail "The current Ego release pointer is unresolved."
 [[ ${release} == "${manifest[expected_release]}" && -d ${release} ]] ||
   fail "The current Ego release changed after cutover preparation."
+cmp --silent \
+  "${stage}/workstations.tsv" \
+  "${release}/deploy/workstations.tsv" ||
+  fail "The staged workstation registry differs from promoted source."
 for protected_parent in /opt/matsci-sam /opt/matsci-sam/releases; do
   [[ -d ${protected_parent} && ! -L ${protected_parent} &&
     $(stat -c '%U:%G:%a' "${protected_parent}") == root:root:755 ]] ||

--- a/deploy/lib/deploy-ego-precutover-remote.sh
+++ b/deploy/lib/deploy-ego-precutover-remote.sh
@@ -444,6 +444,8 @@ for key in "${allowed_keys[@]}"; do
   [[ -v "manifest[${key}]" ]] || fail "The deployment manifest is incomplete."
 done
 [[ ${manifest[format]} == 1 ]] || fail "Unsupported manifest format."
+[[ ${manifest[source_host]} =~ ^[a-z][a-z0-9-]*$ ]] ||
+  fail "Invalid source workstation identifier."
 for key in validated_superego_commit commit tree; do
   [[ ${manifest[${key}]} =~ ^[0-9a-f]{40}$ ]] ||
     fail "Invalid manifest identifier for ${key}."

--- a/deploy/lib/seed-ego-from-superego-remote.sh
+++ b/deploy/lib/seed-ego-from-superego-remote.sh
@@ -387,7 +387,8 @@ if [[ ${mode} == prepare ]]; then
       source.tar \
       superego-database.dump \
       superego-manifest.tsv \
-      verify-migration-ledger.sh |
+      verify-migration-ledger.sh \
+      workstations.tsv |
       sort
   )
 else
@@ -404,7 +405,8 @@ else
       result.tsv \
       seed-ego-from-superego-remote.sh \
       source.tar \
-      verify-migration-ledger.sh |
+      verify-migration-ledger.sh \
+      workstations.tsv |
       sort
   )
 fi
@@ -470,14 +472,15 @@ expected_manifest_keys=$(
     source_archive_sha256 \
     source_host \
     source_manifest_sha256 \
-    validated_superego_commit |
+    validated_superego_commit \
+    workstation_registry_sha256 |
     sort
 )
 actual_manifest_keys=$(printf '%s\n' "${!manifest[@]}" | sort)
 [[ ${actual_manifest_keys} == "${expected_manifest_keys}" ]] ||
   fail "The seed manifest has an unexpected key set."
 [[ ${manifest[format]} == 1 &&
-  ${manifest[source_host]} == pa90 &&
+  ${manifest[source_host]} =~ ^[a-z][a-z0-9-]*$ &&
   ${manifest[expected_authority]} == uninitialized &&
   ${manifest[validated_superego_commit]} =~ ^[0-9a-f]{40}$ &&
   ${manifest[public_commit]} =~ ^[0-9a-f]{40}$ &&
@@ -492,7 +495,7 @@ done
 for key in raw_dump_sha256 source_archive_sha256 source_manifest_sha256 \
   helper_sha256 base_invariants_sha256 privacy_transform_sha256 \
   privacy_invariants_sha256 ledger_verifier_sha256 maintenance_sha256 \
-  operations_sha256
+  operations_sha256 workstation_registry_sha256
 do
   [[ ${manifest[${key}]} =~ ^[0-9a-f]{64}$ ]] ||
     fail "The seed manifest has an invalid ${key}."
@@ -522,6 +525,28 @@ fi
   "${manifest[ledger_verifier_sha256]}" ]]
 [[ $(sha256sum "${input_dir}/matsci-sam-ops" | awk '{print $1}') == \
   "${manifest[operations_sha256]}" ]]
+[[ $(sha256sum "${input_dir}/workstations.tsv" | awk '{print $1}') == \
+  "${manifest[workstation_registry_sha256]}" ]]
+tar --extract \
+  --to-stdout \
+  --file="${input_dir}/source.tar" \
+  source/deploy/workstations.tsv |
+  cmp --silent - "${input_dir}/workstations.tsv" ||
+  fail "The staged workstation registry differs from promoted source."
+
+registered_source=$(
+  awk -F '\t' -v source="${manifest[source_host]}" '
+    /^#/ || /^[[:space:]]*$/ { next }
+    NF != 3 { exit 2 }
+    $1 !~ /^[a-z][a-z0-9-]*$/ { exit 2 }
+    $2 !~ /^[A-Za-z0-9][A-Za-z0-9.-]*$/ { exit 2 }
+    $3 != "yes" && $3 != "no" { exit 2 }
+    ++seen_id[$1] > 1 || ++seen_host[$2] > 1 { exit 2 }
+    $1 == source { print $0 }
+  ' "${input_dir}/workstations.tsv"
+) || fail "The staged workstation registry is malformed."
+[[ -n ${registered_source} && ${registered_source} != *$'\n'* ]] ||
+  fail "The source workstation is not uniquely registered."
 
 exec 9>/run/lock/matsci-sam-operation.lock
 flock --nonblock 9 || fail "Another MatSci operation is running on Ego."

--- a/deploy/lib/verify-superego-public-content.sh
+++ b/deploy/lib/verify-superego-public-content.sh
@@ -59,6 +59,73 @@ if [[ ${1:-} == --print-allowlist && $# -eq 1 ]]; then
   exit 0
 fi
 
+if [[ ${1:-} == --verify-worktree ]]; then
+  [[ $# -eq 3 ]] ||
+    fail "Usage: verify-superego-public-content.sh --verify-worktree REPOSITORY COMMIT"
+
+  repo=$2
+  worktree_commit=$3
+  [[ -d ${repo}/.git && ! -L ${repo}/.git ]] ||
+    fail "The repository path is missing or unsafe."
+  [[ ${worktree_commit} =~ ^[0-9a-f]{40}$ ]] ||
+    fail "The worktree commit identifier is malformed."
+  git -C "${repo}" cat-file -e "${worktree_commit}^{commit}" 2>/dev/null ||
+    fail "The worktree commit is unavailable."
+
+  hidden_index_entries=$(
+    git -C "${repo}" ls-files -v |
+      awk '
+        substr($0, 1, 1) == "S" ||
+        substr($0, 1, 1) ~ /^[a-z]$/ {
+          print substr($0, 3)
+        }
+      '
+  )
+  if [[ -n ${hidden_index_entries} ]]; then
+    echo "The Git index contains hidden worktree state:" >&2
+    printf '%s\n' "${hidden_index_entries}" >&2
+    fail "Refusing assume-unchanged or skip-worktree entries."
+  fi
+
+  expected_tree=$(git -C "${repo}" rev-parse "${worktree_commit}^{tree}")
+  index_tree=$(git -C "${repo}" write-tree)
+  [[ ${index_tree} == "${expected_tree}" ]] ||
+    fail "The Git index does not match the reviewed source tree."
+
+  verified_entries=0
+  while IFS= read -r -d '' tree_entry; do
+    [[ ${tree_entry} == *$'\t'* ]] ||
+      fail "The reviewed source tree contains a malformed entry."
+    entry_metadata=${tree_entry%%$'\t'*}
+    entry_path=${tree_entry#*$'\t'}
+    read -r entry_mode entry_type entry_hash <<<"${entry_metadata}"
+    [[ (${entry_mode} == 100644 || ${entry_mode} == 100755) &&
+      ${entry_type} == blob &&
+      ${entry_hash} =~ ^[0-9a-f]{40}$ &&
+      -n ${entry_path} &&
+      ${entry_path} != /* ]] ||
+      fail "The reviewed source tree contains an unsupported entry."
+
+    worktree_file=${repo}/${entry_path}
+    [[ -f ${worktree_file} && ! -L ${worktree_file} ]] ||
+      fail "A reviewed worktree file is missing or unsafe: ${entry_path}"
+    actual_hash=$(git hash-object --no-filters -- "${worktree_file}")
+    [[ ${actual_hash} == "${entry_hash}" ]] ||
+      fail "A reviewed worktree file differs from source: ${entry_path}"
+    if [[ ${entry_mode} == 100755 ]]; then
+      [[ -x ${worktree_file} ]] ||
+        fail "A reviewed executable lost its executable mode: ${entry_path}"
+    else
+      [[ ! -x ${worktree_file} ]] ||
+        fail "A reviewed non-executable gained executable mode: ${entry_path}"
+    fi
+    ((verified_entries += 1))
+  done < <(git -C "${repo}" ls-tree -r -z "${worktree_commit}")
+  ((verified_entries > 0)) ||
+    fail "The reviewed source tree is empty."
+  exit 0
+fi
+
 if [[ ${1:-} == --create-archive ]]; then
   [[ $# -eq 4 || ($# -eq 5 && ${5} == --prefix=source/) ]] ||
     fail "Usage: verify-superego-public-content.sh --create-archive REPOSITORY COMMIT OUTPUT [--prefix=source/]"

--- a/deploy/lib/verify-superego-public-content.sh
+++ b/deploy/lib/verify-superego-public-content.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+# Local replace refs must never rewrite the reviewed source objects.
+export GIT_NO_REPLACE_OBJECTS=1
+export GIT_ATTR_NOSYSTEM=1
+export GIT_CONFIG_NOSYSTEM=1
+export GIT_CONFIG_GLOBAL=/dev/null
+unset \
+  GIT_ALTERNATE_OBJECT_DIRECTORIES \
+  GIT_COMMON_DIR \
+  GIT_CONFIG_COUNT \
+  GIT_CONFIG_PARAMETERS \
+  GIT_DEFAULT_HASH \
+  GIT_DEFAULT_REF_FORMAT \
+  GIT_DIR \
+  GIT_GLOB_PATHSPECS \
+  GIT_ICASE_PATHSPECS \
+  GIT_INDEX_FILE \
+  GIT_LITERAL_PATHSPECS \
+  GIT_NOGLOB_PATHSPECS \
+  GIT_NAMESPACE \
+  GIT_OBJECT_DIRECTORY \
+  GIT_SHALLOW_FILE \
+  GIT_TEMPLATE_DIR \
+  GIT_WORK_TREE
+
+fail() {
+  echo "$*" >&2
+  exit 1
+}
+
+# These paths are control-plane inputs, not application, schema, migration,
+# dependency, build, service, or runtime-configuration content. Any change
+# outside this exact reviewed list invalidates Superego equivalence.
+operations_only_paths=(
+  .agents/skills/manage-matsci-environments/SKILL.md
+  .agents/skills/manage-matsci-environments/references/environments.md
+  .github/workflows/pr-verify.yml
+  README.md
+  developing.md
+  deploy/README.md
+  deploy/cutover-ego-public.sh
+  deploy/deploy-ego-from-workstation.sh
+  deploy/ego/AGENTS.md
+  deploy/lib/cutover-ego-public-remote.sh
+  deploy/lib/deploy-ego-precutover-remote.sh
+  deploy/lib/export-superego-for-ego-seed-remote.sh
+  deploy/lib/seed-ego-from-superego-remote.sh
+  deploy/lib/verify-superego-public-content.sh
+  deploy/seed-ego-from-superego.sh
+  deploy/workstations.tsv
+  scripts/test-deployment-contract.ts
+)
+
+if [[ ${1:-} == --print-allowlist && $# -eq 1 ]]; then
+  printf '%s\n' "${operations_only_paths[@]}"
+  exit 0
+fi
+
+if [[ ${1:-} == --create-archive ]]; then
+  [[ $# -eq 4 || ($# -eq 5 && ${5} == --prefix=source/) ]] ||
+    fail "Usage: verify-superego-public-content.sh --create-archive REPOSITORY COMMIT OUTPUT [--prefix=source/]"
+
+  repo=$2
+  archive_commit=$3
+  archive_output=$4
+  archive_prefix=
+  [[ $# -eq 4 ]] || archive_prefix=source/
+
+  [[ -d ${repo}/.git && ! -L ${repo}/.git ]] ||
+    fail "The repository path is missing or unsafe."
+  [[ ${archive_commit} =~ ^[0-9a-f]{40}$ ]] ||
+    fail "The archive commit identifier is malformed."
+  git -C "${repo}" cat-file -e "${archive_commit}^{commit}" 2>/dev/null ||
+    fail "The archive commit is unavailable."
+  [[ ${archive_output} == /* && ! -e ${archive_output} &&
+    ! -L ${archive_output} ]] ||
+    fail "The archive output path is unsafe."
+  archive_parent=$(dirname -- "${archive_output}")
+  [[ -d ${archive_parent} && ! -L ${archive_parent} ]] ||
+    fail "The archive output directory is unsafe."
+
+  source_git_dir=$(git -C "${repo}" rev-parse --absolute-git-dir)
+  [[ -d ${source_git_dir}/objects && ! -L ${source_git_dir}/objects ]] ||
+    fail "The repository object store is missing or unsafe."
+
+  isolated_git_dir=$(mktemp -d "${archive_parent}/.matsci-archive-git.XXXXXX")
+  temporary_archive=$(mktemp "${archive_parent}/.matsci-archive.XXXXXX")
+  cleanup_archive() {
+    rm -rf -- "${isolated_git_dir}"
+    rm -f -- "${temporary_archive}"
+  }
+  trap cleanup_archive EXIT
+
+  git init --bare --quiet --object-format=sha1 "${isolated_git_dir}"
+  archive_arguments=(
+    --git-dir="${isolated_git_dir}"
+    -c core.attributesFile=/dev/null
+    archive
+    --format=tar
+    --output="${temporary_archive}"
+  )
+  if [[ -n ${archive_prefix} ]]; then
+    archive_arguments+=(--prefix="${archive_prefix}")
+  fi
+  archive_arguments+=("${archive_commit}")
+  GIT_ALTERNATE_OBJECT_DIRECTORIES="${source_git_dir}/objects" \
+    git "${archive_arguments[@]}"
+  tar --list --file="${temporary_archive}" >/dev/null
+  chmod 0600 "${temporary_archive}"
+  mv -- "${temporary_archive}" "${archive_output}"
+  temporary_archive=
+  rm -rf -- "${isolated_git_dir}"
+  isolated_git_dir=
+  trap - EXIT
+  exit 0
+fi
+
+repo=${1:-}
+validated_commit=${2:-}
+candidate_commit=${3:-}
+
+[[ -n ${repo} && -n ${validated_commit} && -n ${candidate_commit} ]] ||
+  fail "Usage: verify-superego-public-content.sh REPOSITORY VALIDATED_COMMIT CANDIDATE_COMMIT"
+[[ -d ${repo}/.git && ! -L ${repo}/.git ]] ||
+  fail "The repository path is missing or unsafe."
+for commit in "${validated_commit}" "${candidate_commit}"; do
+  [[ ${commit} =~ ^[0-9a-f]{40}$ ]] ||
+    fail "A source commit identifier is malformed."
+  git -C "${repo}" cat-file -e "${commit}^{commit}" 2>/dev/null ||
+    fail "A source commit is unavailable."
+done
+git -C "${repo}" merge-base --is-ancestor \
+  "${validated_commit}" \
+  "${candidate_commit}" ||
+  fail "The public candidate does not descend from the Superego release."
+
+if git -C "${repo}" diff \
+  --quiet \
+  --no-ext-diff \
+  --no-textconv \
+  --no-renames \
+  --ignore-submodules=none \
+  "${validated_commit}" \
+  "${candidate_commit}" \
+  --
+then
+  printf 'exact-tree\n'
+  exit 0
+fi
+
+diff_scope=(.)
+for path in "${operations_only_paths[@]}"; do
+  diff_scope+=(":(top,exclude,literal)${path}")
+done
+
+if ! git -C "${repo}" diff \
+  --quiet \
+  --no-ext-diff \
+  --no-textconv \
+  --no-renames \
+  --ignore-submodules=none \
+  "${validated_commit}" \
+  "${candidate_commit}" \
+  -- \
+  "${diff_scope[@]}"
+then
+  echo "The public candidate changes content not validated on Superego:" >&2
+  git -C "${repo}" diff \
+    --name-only \
+    --no-ext-diff \
+    --no-textconv \
+    --no-renames \
+    --ignore-submodules=none \
+    "${validated_commit}" \
+    "${candidate_commit}" \
+    -- \
+    "${diff_scope[@]}" >&2
+  exit 1
+fi
+
+printf 'reviewed-operations-only\n'

--- a/deploy/seed-ego-from-superego.sh
+++ b/deploy/seed-ego-from-superego.sh
@@ -3,6 +3,7 @@
 set -Eeuo pipefail
 
 umask 0077
+export GIT_NO_REPLACE_OBJECTS=1
 
 script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 repo=$(cd -- "${script_dir}/.." && pwd)
@@ -12,6 +13,7 @@ base_invariants=${script_dir}/lib/reset-db-invariants.sql
 privacy_transform=${script_dir}/lib/ego-public-seed-transform.sql
 privacy_invariants=${script_dir}/lib/ego-public-seed-invariants.sql
 ledger_verifier=${script_dir}/lib/verify-migration-ledger.sh
+superego_content_verifier=${script_dir}/lib/verify-superego-public-content.sh
 maintenance_config=${script_dir}/nginx/matsci-sam-public-maintenance.conf
 operations_file=${script_dir}/ops/matsci-sam-ops
 state_file=${repo}/docs-internal/CURRENT-DEV-STATE.md
@@ -193,6 +195,7 @@ required_files=(
   "${privacy_transform}"
   "${privacy_invariants}"
   "${ledger_verifier}"
+  "${superego_content_verifier}"
   "${maintenance_config}"
   "${operations_file}"
   "${state_file}"
@@ -307,8 +310,12 @@ superego_commit=${superego_name:0:40}
 git -C "${repo}" cat-file -e "${superego_commit}^{commit}" 2>/dev/null ||
   fail "The active Superego commit is not present in local Git history."
 superego_tree=$(git -C "${repo}" rev-parse "${superego_commit}^{tree}")
-[[ ${superego_tree} == "${public_tree}" ]] ||
-  fail "origin/main is not the exact tree currently validated on Superego."
+superego_validation=$(
+  "${superego_content_verifier}" \
+    "${repo}" \
+    "${superego_commit}" \
+    "${public_commit}"
+) || fail "The public application content is not the content validated on Superego."
 
 echo "Checking the public seed contract and migration source."
 (
@@ -380,6 +387,8 @@ REMOTE
 printf '%s\n' "${ego_summary}"
 printf 'public_commit=%s\n' "${public_commit}"
 printf 'validated_superego_commit=%s\n' "${superego_commit}"
+printf 'validated_superego_tree=%s\n' "${superego_tree}"
+printf 'superego_validation=%s\n' "${superego_validation}"
 
 if [[ ${check_only} == true ]]; then
   echo "One-time Ego seed prerequisites passed."
@@ -504,12 +513,12 @@ done
   fail "The transferred Superego snapshot checksum does not match."
 
 source_archive=${work_dir}/source.tar
-git -C "${repo}" archive \
-  --format=tar \
-  --prefix=source/ \
+"${superego_content_verifier}" \
+  --create-archive \
+  "${repo}" \
   "${public_commit}" \
-  >"${source_archive}"
-tar --list --file="${source_archive}" >/dev/null
+  "${source_archive}" \
+  --prefix=source/
 
 {
   printf 'format\t1\n'
@@ -543,6 +552,8 @@ tar --list --file="${source_archive}" >/dev/null
   printf 'maintenance_sha256\t%s\n' "${maintenance_sha}"
   printf 'operations_sha256\t%s\n' \
     "$(sha256sum "${operations_file}" | awk '{print $1}')"
+  printf 'workstation_registry_sha256\t%s\n' \
+    "$(sha256sum "${workstation_registry}" | awk '{print $1}')"
 } >"${seed_manifest}"
 chmod 0600 "${seed_manifest}" "${source_archive}"
 
@@ -574,6 +585,7 @@ scp \
   "${seed_manifest}" \
   "${source_archive}" \
   "${source_manifest}" \
+  "${workstation_registry}" \
   "ego:${ego_dir}/"
 ssh ego "chmod 0600 '${ego_dir}'/*"
 

--- a/deploy/seed-ego-from-superego.sh
+++ b/deploy/seed-ego-from-superego.sh
@@ -4,6 +4,24 @@ set -Eeuo pipefail
 
 umask 0077
 export GIT_NO_REPLACE_OBJECTS=1
+unset \
+  GIT_ALTERNATE_OBJECT_DIRECTORIES \
+  GIT_COMMON_DIR \
+  GIT_CONFIG_COUNT \
+  GIT_CONFIG_PARAMETERS \
+  GIT_DEFAULT_HASH \
+  GIT_DEFAULT_REF_FORMAT \
+  GIT_DIR \
+  GIT_GLOB_PATHSPECS \
+  GIT_ICASE_PATHSPECS \
+  GIT_INDEX_FILE \
+  GIT_LITERAL_PATHSPECS \
+  GIT_NOGLOB_PATHSPECS \
+  GIT_NAMESPACE \
+  GIT_OBJECT_DIRECTORY \
+  GIT_SHALLOW_FILE \
+  GIT_TEMPLATE_DIR \
+  GIT_WORK_TREE
 
 script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 repo=$(cd -- "${script_dir}/.." && pwd)
@@ -50,6 +68,39 @@ USAGE
 fail() {
   echo "$*" >&2
   exit 1
+}
+
+verify_reviewed_worktree() {
+  local commit=$1
+  local helper_path=deploy/lib/verify-superego-public-content.sh
+  local helper_entry
+  local helper_mode
+  local helper_type
+  local expected_hash
+  local entry_path
+  local actual_hash
+
+  helper_entry=$(git -C "${repo}" ls-tree "${commit}" -- "${helper_path}")
+  [[ -n ${helper_entry} && ${helper_entry} != *$'\n'* ]] ||
+    fail "The reviewed source does not uniquely identify the content verifier."
+  read -r helper_mode helper_type expected_hash entry_path <<<"${helper_entry}"
+  [[ ${helper_mode} == 100755 &&
+    ${helper_type} == blob &&
+    ${expected_hash} =~ ^[0-9a-f]{40}$ &&
+    ${entry_path} == "${helper_path}" &&
+    -f ${superego_content_verifier} &&
+    ! -L ${superego_content_verifier} &&
+    -x ${superego_content_verifier} ]] ||
+    fail "The reviewed content verifier contract is invalid."
+  actual_hash=$(
+    git -C "${repo}" hash-object \
+      --no-filters \
+      -- "${superego_content_verifier}"
+  )
+  [[ ${actual_hash} == "${expected_hash}" ]] ||
+    fail "The executed content verifier differs from reviewed source."
+  "${superego_content_verifier}" --verify-worktree "${repo}" "${commit}" ||
+    fail "The raw worktree does not match reviewed source."
 }
 
 remove_remote_stage() {
@@ -276,6 +327,7 @@ public_tree=$(git -C "${repo}" rev-parse "${public_commit}^{tree}")
 dev_tree=$(git -C "${repo}" rev-parse "${origin_dev}^{tree}")
 [[ ${public_tree} == "${dev_tree}" ]] ||
   fail "origin/main does not contain the exact reviewed origin/dev tree."
+verify_reviewed_worktree "${public_commit}"
 git -C "${repo}" show "${public_commit}:lib/apis/ollama.ts" |
   grep -q 'EGO_SEED_CHAT_FALLBACK' ||
   fail "The promoted public tree lacks the seeded-chat reconstruction fallback."
@@ -330,6 +382,7 @@ git -C "${repo}" fetch --prune origin dev main
   $(git -C "${repo}" rev-parse refs/remotes/origin/main) == "${public_commit}" &&
   $(git -C "${repo}" rev-parse "${public_commit}^{tree}") == "${public_tree}" ]] ||
   fail "Reviewed source changed during the seed contract checks."
+verify_reviewed_worktree "${public_commit}"
 
 maintenance_sha=$(sha256sum "${maintenance_config}" | awk '{print $1}')
 ego_summary=$(
@@ -512,6 +565,7 @@ done
   "${source[dump_sha256]}" ]] ||
   fail "The transferred Superego snapshot checksum does not match."
 
+verify_reviewed_worktree "${public_commit}"
 source_archive=${work_dir}/source.tar
 "${superego_content_verifier}" \
   --create-archive \
@@ -564,6 +618,7 @@ git -C "${repo}" fetch --prune origin dev main
   $(git -C "${repo}" rev-parse refs/remotes/origin/main) == "${public_commit}" &&
   $(git -C "${repo}" rev-parse "${public_commit}^{tree}") == "${public_tree}" ]] ||
   fail "Reviewed source changed while the seed snapshot was prepared."
+verify_reviewed_worktree "${public_commit}"
 
 ego_id="seed-${public_commit:0:12}-$(date -u +%Y%m%dT%H%M%SZ)"
 ego_dir="/home/cr625/ego-admin/incoming/${ego_id}"

--- a/deploy/workstations.tsv
+++ b/deploy/workstations.tsv
@@ -1,2 +1,3 @@
 # id	hostname	snapshot-recipient
+area51	Area51	no
 pa90	CBR-PA90	yes

--- a/developing.md
+++ b/developing.md
@@ -675,8 +675,11 @@ independent public database after initialization.
 The legacy deployment workflows are disabled. Do not merge or push a public
 candidate to `main` until their self-hosted runners and deployment privileges
 are retired and the old deployment workflow is removed. After that boundary
-is verified, promote only a Git tree already deployed and validated on
-Superego, then build it independently on Ego under the protected public
+is verified, keep reviewed `dev` and promoted `main` on the same exact tree.
+Require the application, schema, migration, dependency, build, service, and
+runtime-configuration content to match the release already validated on
+Superego; only the exact reviewed non-runtime operations allowlist may differ.
+Then build the promoted tree independently on Ego under the protected public
 environment.
 
 Before deployment, decide which database contains the authoritative data. A

--- a/scripts/test-deployment-contract.ts
+++ b/scripts/test-deployment-contract.ts
@@ -100,6 +100,10 @@ assert.match(
   /--no-ext-diff[\s\S]*--no-textconv[\s\S]*--no-renames[\s\S]*--ignore-submodules=none/
 )
 assert.match(superegoContentVerifier, /export GIT_NO_REPLACE_OBJECTS=1/)
+assert.match(
+  superegoContentVerifier,
+  /--verify-worktree[\s\S]*ls-files -v[\s\S]*write-tree[\s\S]*hash-object --no-filters/
+)
 
 const equivalenceDirectory = mkdtempSync(
   resolve(tmpdir(), "matsci-sam-source-equivalence-")
@@ -146,6 +150,46 @@ try {
     ).trim(),
     "exact-tree"
   )
+  execFileSync(
+    resolve(root, "deploy/lib/verify-superego-public-content.sh"),
+    ["--verify-worktree", equivalenceDirectory, validatedCommit],
+    { stdio: "pipe" }
+  )
+
+  const hiddenVerifierPath =
+    "deploy/lib/verify-superego-public-content.sh"
+  for (const [hide, unhide] of [
+    ["--skip-worktree", "--no-skip-worktree"],
+    ["--assume-unchanged", "--no-assume-unchanged"]
+  ] as const) {
+    runGit("update-index", hide, hiddenVerifierPath)
+    writeFileSync(
+      resolve(equivalenceDirectory, hiddenVerifierPath),
+      `hidden modification via ${hide}\n`
+    )
+    assert.equal(
+      runGit("status", "--porcelain=v1"),
+      "",
+      `${hide} no longer reproduces an empty porcelain status`
+    )
+    assert.throws(() =>
+      execFileSync(
+        resolve(root, "deploy/lib/verify-superego-public-content.sh"),
+        ["--verify-worktree", equivalenceDirectory, validatedCommit],
+        { stdio: "pipe" }
+      )
+    )
+    runGit("update-index", unhide, hiddenVerifierPath)
+    writeFileSync(
+      resolve(equivalenceDirectory, hiddenVerifierPath),
+      `validated ${hiddenVerifierPath}\n`
+    )
+    execFileSync(
+      resolve(root, "deploy/lib/verify-superego-public-content.sh"),
+      ["--verify-worktree", equivalenceDirectory, validatedCommit],
+      { stdio: "pipe" }
+    )
+  }
 
   const archiveDirectory = mkdtempSync(
     resolve(tmpdir(), "matsci-sam-source-archive-")
@@ -815,6 +859,18 @@ const egoCutoverWrapper = read("deploy/cutover-ego-public.sh")
 const egoCutoverRemote = read(
   "deploy/lib/cutover-ego-public-remote.sh"
 )
+for (const wrapper of [
+  egoSeedWrapper,
+  egoReleaseWrapper,
+  egoCutoverWrapper
+]) {
+  assert.match(wrapper, /verify_reviewed_worktree\(\)/)
+  assert.match(
+    wrapper,
+    /hash-object[\s\S]*--no-filters[\s\S]*--verify-worktree/
+  )
+  assert.match(wrapper, /unset[\s\S]*GIT_INDEX_FILE/)
+}
 for (const wrapper of [
   egoReleaseWrapper,
   egoCutoverWrapper

--- a/scripts/test-deployment-contract.ts
+++ b/scripts/test-deployment-contract.ts
@@ -2,17 +2,381 @@ import assert from "node:assert/strict"
 import { execFileSync } from "node:child_process"
 import { createHash } from "node:crypto"
 import {
+  chmodSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
+  renameSync,
   rmSync,
   writeFileSync
 } from "node:fs"
 import { tmpdir } from "node:os"
-import { resolve } from "node:path"
+import { dirname, resolve } from "node:path"
 
 const root = process.cwd()
 
 const read = (path: string) => readFileSync(resolve(root, path), "utf8")
+
+const workstationRows = read("deploy/workstations.tsv")
+  .split(/\r?\n/)
+  .map((line) => line.trim())
+  .filter((line) => line && !line.startsWith("#"))
+  .map((line) => line.split("\t"))
+assert(workstationRows.length > 0, "The workstation registry is empty")
+const workstationIds = new Set<string>()
+const workstationHosts = new Set<string>()
+for (const [id, host, snapshotRecipient, ...extra] of workstationRows) {
+  assert.match(id, /^[a-z][a-z0-9-]*$/, "Invalid workstation ID")
+  assert.match(
+    host,
+    /^[A-Za-z0-9][A-Za-z0-9.-]*$/,
+    "Invalid workstation hostname"
+  )
+  assert(
+    snapshotRecipient === "yes" || snapshotRecipient === "no",
+    "Invalid snapshot permission"
+  )
+  assert.equal(extra.length, 0, "The workstation registry has extra fields")
+  assert(!workstationIds.has(id), `Duplicate workstation ID: ${id}`)
+  assert(!workstationHosts.has(host), `Duplicate workstation host: ${host}`)
+  workstationIds.add(id)
+  workstationHosts.add(host)
+}
+
+const superegoContentVerifier = read(
+  "deploy/lib/verify-superego-public-content.sh"
+)
+const operationsOnlyMatch = superegoContentVerifier.match(
+  /operations_only_paths=\(\n([\s\S]*?)\n\)/
+)
+assert(
+  operationsOnlyMatch,
+  "Could not locate the reviewed operations-only path list"
+)
+const expectedOperationsOnlyPaths = [
+  ".agents/skills/manage-matsci-environments/SKILL.md",
+  ".agents/skills/manage-matsci-environments/references/environments.md",
+  ".github/workflows/pr-verify.yml",
+  "README.md",
+  "developing.md",
+  "deploy/README.md",
+  "deploy/cutover-ego-public.sh",
+  "deploy/deploy-ego-from-workstation.sh",
+  "deploy/ego/AGENTS.md",
+  "deploy/lib/cutover-ego-public-remote.sh",
+  "deploy/lib/deploy-ego-precutover-remote.sh",
+  "deploy/lib/export-superego-for-ego-seed-remote.sh",
+  "deploy/lib/seed-ego-from-superego-remote.sh",
+  "deploy/lib/verify-superego-public-content.sh",
+  "deploy/seed-ego-from-superego.sh",
+  "deploy/workstations.tsv",
+  "scripts/test-deployment-contract.ts"
+]
+assert.deepEqual(
+  operationsOnlyMatch[1]
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean),
+  expectedOperationsOnlyPaths
+)
+assert.equal(
+  execFileSync(
+    resolve(root, "deploy/lib/verify-superego-public-content.sh"),
+    ["--print-allowlist"],
+    { encoding: "utf8" }
+  ).trim(),
+  operationsOnlyMatch[1]
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join("\n")
+)
+assert.match(
+  superegoContentVerifier,
+  /merge-base --is-ancestor[\s\S]*validated_commit[\s\S]*candidate_commit/
+)
+assert.match(
+  superegoContentVerifier,
+  /--no-ext-diff[\s\S]*--no-textconv[\s\S]*--no-renames[\s\S]*--ignore-submodules=none/
+)
+assert.match(superegoContentVerifier, /export GIT_NO_REPLACE_OBJECTS=1/)
+
+const equivalenceDirectory = mkdtempSync(
+  resolve(tmpdir(), "matsci-sam-source-equivalence-")
+)
+const runGit = (...args: string[]) =>
+  execFileSync("git", ["-C", equivalenceDirectory, ...args], {
+    encoding: "utf8"
+  }).trim()
+const commitIndex = (message: string) => {
+  runGit(
+    "-c",
+    "user.name=MatSci deployment test",
+    "-c",
+    "user.email=deployment-test@example.invalid",
+    "commit",
+    "--quiet",
+    "-m",
+    message
+  )
+  return runGit("rev-parse", "HEAD")
+}
+const commitFixture = (message: string) => {
+  runGit("add", ".")
+  return commitIndex(message)
+}
+try {
+  runGit("init", "--quiet")
+  for (const path of expectedOperationsOnlyPaths) {
+    const fixture = resolve(equivalenceDirectory, path)
+    mkdirSync(dirname(fixture), { recursive: true })
+    writeFileSync(fixture, `validated ${path}\n`)
+  }
+  mkdirSync(resolve(equivalenceDirectory, "app"), { recursive: true })
+  writeFileSync(
+    resolve(equivalenceDirectory, "app/page.tsx"),
+    "export default function Page() { return null }\n"
+  )
+  const validatedCommit = commitFixture("validated application")
+  assert.equal(
+    execFileSync(
+      resolve(root, "deploy/lib/verify-superego-public-content.sh"),
+      [equivalenceDirectory, validatedCommit, validatedCommit],
+      { encoding: "utf8" }
+    ).trim(),
+    "exact-tree"
+  )
+
+  const archiveDirectory = mkdtempSync(
+    resolve(tmpdir(), "matsci-sam-source-archive-")
+  )
+  try {
+    const ambientAttributes = resolve(
+      equivalenceDirectory,
+      ".git/info/attributes"
+    )
+    writeFileSync(ambientAttributes, "app/page.tsx export-ignore\n")
+    const unsafeArchive = resolve(archiveDirectory, "unsafe.tar")
+    execFileSync(
+      "git",
+      [
+        "-C",
+        equivalenceDirectory,
+        "archive",
+        "--format=tar",
+        `--output=${unsafeArchive}`,
+        validatedCommit
+      ],
+      { stdio: "pipe" }
+    )
+    const unsafeEntries = execFileSync(
+      "tar",
+      ["--list", `--file=${unsafeArchive}`],
+      { encoding: "utf8" }
+    )
+    assert(
+      !unsafeEntries.split("\n").includes("app/page.tsx"),
+      "The ambient export-ignore regression fixture is ineffective"
+    )
+
+    const globalAttributes = resolve(archiveDirectory, "global-attributes")
+    writeFileSync(globalAttributes, "app/page.tsx export-ignore\n")
+    const maliciousTemplate = resolve(archiveDirectory, "template")
+    mkdirSync(resolve(maliciousTemplate, "info"), { recursive: true })
+    writeFileSync(
+      resolve(maliciousTemplate, "info/attributes"),
+      "app/page.tsx export-ignore\n"
+    )
+    const hostileGitEnvironment = {
+      ...process.env,
+      GIT_CONFIG_COUNT: "1",
+      GIT_CONFIG_KEY_0: "core.attributesFile",
+      GIT_CONFIG_VALUE_0: globalAttributes,
+      GIT_TEMPLATE_DIR: maliciousTemplate
+    }
+    for (const [name, prefix, expectedEntry] of [
+      ["root.tar", undefined, "app/page.tsx"],
+      ["prefixed.tar", "--prefix=source/", "source/app/page.tsx"]
+    ] as const) {
+      const safeArchive = resolve(archiveDirectory, name)
+      const arguments_ = [
+        "--create-archive",
+        equivalenceDirectory,
+        validatedCommit,
+        safeArchive
+      ]
+      if (prefix) arguments_.push(prefix)
+      execFileSync(
+        resolve(root, "deploy/lib/verify-superego-public-content.sh"),
+        arguments_,
+        { env: hostileGitEnvironment, stdio: "pipe" }
+      )
+      const safeEntries = execFileSync(
+        "tar",
+        ["--list", `--file=${safeArchive}`],
+        { encoding: "utf8" }
+      )
+      assert(
+        safeEntries.split("\n").includes(expectedEntry),
+        "The reviewed archive inherited ambient export-ignore attributes"
+      )
+    }
+  } finally {
+    rmSync(archiveDirectory, { recursive: true, force: true })
+  }
+
+  for (const path of expectedOperationsOnlyPaths) {
+    writeFileSync(
+      resolve(equivalenceDirectory, path),
+      `reviewed operations change ${path}\n`
+    )
+  }
+  const operationsCommit = commitFixture("change reviewed operations")
+  assert.equal(
+    execFileSync(
+      resolve(root, "deploy/lib/verify-superego-public-content.sh"),
+      [equivalenceDirectory, validatedCommit, operationsCommit],
+      { encoding: "utf8" }
+    ).trim(),
+    "reviewed-operations-only"
+  )
+
+  writeFileSync(
+    resolve(equivalenceDirectory, "app/page.tsx"),
+    "export default function Page() { return <main>changed</main> }\n"
+  )
+  const applicationCommit = commitFixture("change application")
+  assert.throws(() =>
+    execFileSync(
+      resolve(root, "deploy/lib/verify-superego-public-content.sh"),
+      [equivalenceDirectory, validatedCommit, applicationCommit],
+      { stdio: "pipe" }
+    )
+  )
+  const validatedTree = runGit("rev-parse", `${validatedCommit}^{tree}`)
+  const replacementCommit = runGit(
+    "-c",
+    "user.name=MatSci deployment test",
+    "-c",
+    "user.email=deployment-test@example.invalid",
+    "commit-tree",
+    validatedTree,
+    "-p",
+    validatedCommit,
+    "-m",
+    "malicious local replacement"
+  )
+  runGit("replace", applicationCommit, replacementCommit)
+  assert.throws(() =>
+    execFileSync(
+      resolve(root, "deploy/lib/verify-superego-public-content.sh"),
+      [equivalenceDirectory, validatedCommit, applicationCommit],
+      { stdio: "pipe" }
+    )
+  )
+  runGit("replace", "-d", applicationCommit)
+
+  writeFileSync(
+    resolve(equivalenceDirectory, "app/page.tsx"),
+    "export default function Page() { return null }\n"
+  )
+  mkdirSync(resolve(equivalenceDirectory, "drizzle"), { recursive: true })
+  writeFileSync(
+    resolve(equivalenceDirectory, "drizzle/schema.ts"),
+    "export const changedSchema = true\n"
+  )
+  const schemaCommit = commitFixture("change schema")
+  assert.throws(() =>
+    execFileSync(
+      resolve(root, "deploy/lib/verify-superego-public-content.sh"),
+      [equivalenceDirectory, validatedCommit, schemaCommit],
+      { stdio: "pipe" }
+    )
+  )
+
+  rmSync(resolve(equivalenceDirectory, "drizzle"), {
+    recursive: true,
+    force: true
+  })
+  writeFileSync(resolve(equivalenceDirectory, "pnpm-lock.yaml"), "changed\n")
+  const dependencyCommit = commitFixture("change dependency lock")
+  assert.throws(() =>
+    execFileSync(
+      resolve(root, "deploy/lib/verify-superego-public-content.sh"),
+      [equivalenceDirectory, validatedCommit, dependencyCommit],
+      { stdio: "pipe" }
+    )
+  )
+
+  rmSync(resolve(equivalenceDirectory, "pnpm-lock.yaml"))
+  writeFileSync(
+    resolve(equivalenceDirectory, "deploy/lib/reset-db-invariants.sql"),
+    "SELECT false;\n"
+  )
+  const invariantCommit = commitFixture("change protected invariant")
+  assert.throws(() =>
+    execFileSync(
+      resolve(root, "deploy/lib/verify-superego-public-content.sh"),
+      [equivalenceDirectory, validatedCommit, invariantCommit],
+      { stdio: "pipe" }
+    )
+  )
+
+  rmSync(resolve(equivalenceDirectory, "deploy/lib/reset-db-invariants.sql"))
+  chmodSync(resolve(equivalenceDirectory, "app/page.tsx"), 0o755)
+  const modeCommit = commitFixture("change application mode")
+  assert.throws(() =>
+    execFileSync(
+      resolve(root, "deploy/lib/verify-superego-public-content.sh"),
+      [equivalenceDirectory, validatedCommit, modeCommit],
+      { stdio: "pipe" }
+    )
+  )
+
+  chmodSync(resolve(equivalenceDirectory, "app/page.tsx"), 0o644)
+  renameSync(
+    resolve(equivalenceDirectory, "deploy/README.md"),
+    resolve(equivalenceDirectory, "app/deploy-readme.md")
+  )
+  const moveCommit = commitFixture("move allowed path into application")
+  assert.throws(() =>
+    execFileSync(
+      resolve(root, "deploy/lib/verify-superego-public-content.sh"),
+      [equivalenceDirectory, validatedCommit, moveCommit],
+      { stdio: "pipe" }
+    )
+  )
+  assert.throws(() =>
+    execFileSync(
+      resolve(root, "deploy/lib/verify-superego-public-content.sh"),
+      [equivalenceDirectory, "not-a-commit", moveCommit],
+      { stdio: "pipe" }
+    )
+  )
+
+  renameSync(
+    resolve(equivalenceDirectory, "app/deploy-readme.md"),
+    resolve(equivalenceDirectory, "deploy/README.md")
+  )
+  runGit("add", ".")
+  runGit("config", "diff.ignoreSubmodules", "all")
+  runGit(
+    "update-index",
+    "--add",
+    "--cacheinfo",
+    `160000,${operationsCommit},vendor/ignored`
+  )
+  const gitlinkCommit = commitIndex("add disallowed gitlink")
+  assert.throws(() =>
+    execFileSync(
+      resolve(root, "deploy/lib/verify-superego-public-content.sh"),
+      [equivalenceDirectory, validatedCommit, gitlinkCommit],
+      { stdio: "pipe" }
+    )
+  )
+} finally {
+  rmSync(equivalenceDirectory, { recursive: true, force: true })
+}
 
 const parseAssignments = (path: string) => {
   const result = new Map<string, string>()
@@ -158,6 +522,7 @@ const egoSeedTransform = read(
 const egoSeedInvariants = read(
   "deploy/lib/ego-public-seed-invariants.sql"
 )
+assert.match(egoSeedWrapper, /export GIT_NO_REPLACE_OBJECTS=1/)
 
 const seedEnvironmentProgram = egoSeedHelper.match(
   /environment_contract=\$\(\s+awk -F= '\n([\s\S]*?)\n  ' \/etc\/matsci-sam\/app\.env \|/
@@ -213,8 +578,15 @@ try {
 assert.match(egoSeedWrapper, /EGO_SEED_CHAT_FALLBACK/)
 assert.match(
   egoSeedWrapper,
-  /git -C "\$\{repo\}" archive[\s\S]*"\$\{public_commit\}"/
+  /superego_content_verifier[\s\S]*superego_commit[\s\S]*public_commit/
 )
+assert.match(egoSeedWrapper, /public_tree} == "\$\{dev_tree\}"/)
+assert.doesNotMatch(egoSeedWrapper, /superego_tree} == "\$\{public_tree\}"/)
+assert.match(
+  egoSeedWrapper,
+  /superego_content_verifier}"[\s\S]*--create-archive[\s\S]*public_commit[\s\S]*--prefix=source\//
+)
+assert.doesNotMatch(egoSeedWrapper, /git -C "\$\{repo\}" archive/)
 assert.match(
   egoSeedWrapper,
   /\.local\/state\/matsci-sam\/backups/
@@ -247,6 +619,23 @@ assert(!egoSeedHelper.includes("md5("))
 assert.match(egoSeedHelper, /CREATE EXTENSION IF NOT EXISTS vector/)
 assert.match(egoSeedHelper, /assert_pgvector "\$\{database\}"/)
 assert.match(egoSeedHelper, /phase\]} == offhost-verified/)
+assert.match(
+  egoSeedHelper,
+  /workstations\.tsv[\s\S]*source workstation is not uniquely registered/
+)
+const seedSourceGrammarIndex = egoSeedHelper.indexOf(
+  "${manifest[source_host]} =~ ^[a-z][a-z0-9-]*$"
+)
+assert(
+  seedSourceGrammarIndex >= 0 &&
+    seedSourceGrammarIndex < egoSeedHelper.indexOf("registered_source=$("),
+  "The seed helper must validate source_host before its registry lookup"
+)
+assert.match(
+  egoSeedHelper,
+  /source\/deploy\/workstations\.tsv[\s\S]*cmp --silent/
+)
+assert.doesNotMatch(egoSeedHelper, /manifest\[source_host\]\} == pa90/)
 assert.match(egoSeedHelper, /admin_state=\/var\/lib\/matsci-sam-admin/)
 assert.match(egoSeedHelper, /backup_dir=\$\{admin_state\}\/backups/)
 assert.match(egoSeedHelper, /stat -c '%U:%G:%a'[\s\S]*root:root:700/)
@@ -426,10 +815,33 @@ const egoCutoverWrapper = read("deploy/cutover-ego-public.sh")
 const egoCutoverRemote = read(
   "deploy/lib/cutover-ego-public-remote.sh"
 )
+for (const wrapper of [
+  egoReleaseWrapper,
+  egoCutoverWrapper
+]) {
+  assert.match(wrapper, /export GIT_NO_REPLACE_OBJECTS=1/)
+}
+for (const [name, remote] of [
+  ["first-release", egoReleaseRemote],
+  ["cutover", egoCutoverRemote]
+] as const) {
+  const grammarIndex = remote.indexOf(
+    "${manifest[source_host]} =~ ^[a-z][a-z0-9-]*$"
+  )
+  const lookupIndex = remote.indexOf("registered_source=$(")
+  assert(
+    grammarIndex >= 0 && grammarIndex < lookupIndex,
+    `The ${name} helper must validate source_host before its registry lookup`
+  )
+}
 
 assert.match(egoReleaseWrapper, /state_authority} == ego/)
 assert.match(egoReleaseWrapper, /remote_authority} == ego/)
 assert.match(
+  egoReleaseWrapper,
+  /superego_content_verifier[\s\S]*superego_commit[\s\S]*candidate/
+)
+assert.doesNotMatch(
   egoReleaseWrapper,
   /candidate_tree} == "\$\{superego_tree\}"/
 )
@@ -437,6 +849,11 @@ assert.match(
   egoReleaseWrapper,
   /candidate_tree} == "\$\{dev_tree\}"/
 )
+assert.match(
+  egoReleaseWrapper,
+  /superego_content_verifier}"[\s\S]*--create-archive[\s\S]*candidate/
+)
+assert.doesNotMatch(egoReleaseWrapper, /git -C "\$\{repo\}" archive/)
 assert.match(
   egoReleaseWrapper,
   /release=absent\\nservice=inactive\\nenabled=disabled/
@@ -555,6 +972,19 @@ assert.match(
   egoCutoverWrapper,
   /second gate requires a real browser Google login/
 )
+assert.match(
+  egoCutoverWrapper,
+  /workstation_registry_sha256[\s\S]*workstations\.tsv/
+)
+assert.match(
+  egoCutoverRemote,
+  /workstations\.tsv[\s\S]*source workstation is not uniquely registered/
+)
+assert.match(
+  egoCutoverRemote,
+  /stage}\/workstations\.tsv[\s\S]*release}\/deploy\/workstations\.tsv/
+)
+assert.doesNotMatch(egoCutoverRemote, /manifest\[source_host\]\} == pa90/)
 assert.match(egoCutoverRemote, /\[\[ -t 0 && -t 1 \]\]/)
 assert.match(
   egoCutoverRemote,


### PR DESCRIPTION
## What changed

- Register Area51 as a deployment workstation without snapshot-recipient authority.
- Replace the Superego/public exact-tree coupling with a fail-closed, exact operations-only allowlist while preserving exact `origin/dev == origin/main` tree equality.
- Bind seed and cutover manifests to the reviewed workstation registry and resolve the source workstation dynamically instead of hardcoding PA90.
- Isolate Git archive creation from ambient repository, user, and system attributes so untracked `export-ignore` rules cannot alter the Ego artifact.
- Update deployment policy, runbooks, CI syntax coverage, and contract tests.

## Why

PR #23 fixed pgvector-aware Ego restore behavior, but Superego still runs `62c9839`. The public workflow previously required the entire Superego and public Git trees to match, forcing an unnecessary Superego application redeployment for operations-only changes. Area51 onboarding also exposed PA90 hardcoding in the seed and cutover remote contracts.

The archive path additionally trusted ambient Git attributes: a clean `.git/info/attributes` file could omit validated application content from `git archive` after equivalence checks passed. Archives now use isolated temporary bare metadata backed only by the reviewed object store.

## Impact

The candidate remains an exact reviewed `dev`/`main` tree. Application, schema, migrations, dependencies, build inputs, service definitions, and runtime configuration must still match the Superego-validated release. Only the explicitly tested 17-path operations allowlist may differ. This lets the reviewed Ego workflow proceed from Area51 without an otherwise identical Superego rebuild.

No service, database, authority marker, or public cutover is changed by this PR.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm lint` (0 errors; 2 existing React Compiler compatibility warnings)
- `pnpm check-types`
- `pnpm test:auth`
- `pnpm test:identifiers`
- `pnpm test:interface`
- `pnpm test:ollama-context`
- `pnpm test:deployment`
- CI-equivalent `bash -n` deployment script set
- `pnpm db:check`
- production `pnpm build` under Node 24.18.0
- `62c9839 -> d7f0693` classified as `reviewed-operations-only`, with changed paths exactly equal to the allowlist
- Area51 key authentication verified independently against `cci-superego` and `cci-ego`
