### PR TITLE
fix(deploy): raise Ego seed build heap

### DIFF
--- a/deploy/lib/seed-ego-from-superego-remote.sh
+++ b/deploy/lib/seed-ego-from-superego-remote.sh
@@ -932,7 +932,7 @@ export DATABASE_URL="postgresql:///${scratch_database}?host=/var/run/postgresql"
 cd "${source_dir}"
 /usr/bin/pnpm install --frozen-lockfile
 /usr/bin/pnpm db:migrate
-/usr/bin/pnpm build
+NODE_OPTIONS=--max-old-space-size=3072 /usr/bin/pnpm build
 BUILD
 run_invariants "${check_database}" "${input_dir}/reset-db-invariants.sql"
 run_invariants "${check_database}" "${input_dir}/ego-public-seed-invariants.sql"

--- a/scripts/test-deployment-contract.ts
+++ b/scripts/test-deployment-contract.ts
@@ -651,7 +651,10 @@ assert.match(
 )
 assert.match(egoSeedHelper, /pnpm install --frozen-lockfile/)
 assert.match(egoSeedHelper, /pnpm db:migrate/)
-assert.match(egoSeedHelper, /pnpm build/)
+assert.match(
+  egoSeedHelper,
+  /NODE_OPTIONS=--max-old-space-size=3072 \/usr\/bin\/pnpm build/
+)
 assert.match(egoSeedHelper, /install -o root -g root -m 0400/)
 assert.match(egoSeedHelper, /install -o cr625[\s\S]*-m 0600/)
 assert.match(egoSeedHelper, /old_operations_sha=/)


### PR DESCRIPTION
## Summary

- give the one-time Ego seed build the same 3072 MiB Node heap limit already used by every other protected remote build path
- require that exact bounded build command in the deployment contract

## Operational evidence

- the fresh seed failed during its isolated Next.js build at the default V8 heap ceiling near 1.9 GiB
- Ego still had about 3.1 GiB available; there was no kernel OOM, disk pressure, PostgreSQL error, live database, release, backup, or authority mutation
- both changed paths are in the reviewed operations-only allowlist, so this does not require a Superego application redeployment
- a retry must use the workstation wrapper and a new transient stage; the old seed is not reused

## Verification

- `git diff --check`
- `bash -n deploy/lib/seed-ego-from-superego-remote.sh`
- complete local PR Verify suite on Node 24.18.0 / pnpm 10.34.5
- independent no-blocker deployment review
