### PR TITLE
Promote Ego seed build-heap fix to main

### DIFF
--- a/deploy/lib/seed-ego-from-superego-remote.sh
+++ b/deploy/lib/seed-ego-from-superego-remote.sh
@@ -932,7 +932,7 @@ export DATABASE_URL="postgresql:///${scratch_database}?host=/var/run/postgresql"
 cd "${source_dir}"
 /usr/bin/pnpm install --frozen-lockfile
 /usr/bin/pnpm db:migrate
-/usr/bin/pnpm build
+NODE_OPTIONS=--max-old-space-size=3072 /usr/bin/pnpm build
 BUILD
 run_invariants "${check_database}" "${input_dir}/reset-db-invariants.sql"
 run_invariants "${check_database}" "${input_dir}/ego-public-seed-invariants.sql"

--- a/scripts/test-deployment-contract.ts
+++ b/scripts/test-deployment-contract.ts
@@ -651,7 +651,10 @@ assert.match(
 )
 assert.match(egoSeedHelper, /pnpm install --frozen-lockfile/)
 assert.match(egoSeedHelper, /pnpm db:migrate/)
-assert.match(egoSeedHelper, /pnpm build/)
+assert.match(
+  egoSeedHelper,
+  /NODE_OPTIONS=--max-old-space-size=3072 \/usr\/bin\/pnpm build/
+)
 assert.match(egoSeedHelper, /install -o root -g root -m 0400/)
 assert.match(egoSeedHelper, /install -o cr625[\s\S]*-m 0600/)
 assert.match(egoSeedHelper, /old_operations_sha=/)


### PR DESCRIPTION
Promote reviewed `dev` to `main` so both branches carry the exact same tree
required by the Ego seed source validation.

The delta is PR #26: the seed helper's scratch Next.js build now runs with
`NODE_OPTIONS=--max-old-space-size=3072`, matching the established heap limit
on every other protected remote build path, and the deployment-contract test
pins that invariant. This removes the third seed failure (build worker abort
at the default V8 heap ceiling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)