### PR TITLE
Fix Ego release-parent setgid protection

### DIFF
--- a/deploy/lib/deploy-ego-precutover-remote.sh
+++ b/deploy/lib/deploy-ego-precutover-remote.sh
@@ -533,7 +533,7 @@ for protected_parent in "${app_root}" "${app_root}/releases"; do
   [[ -d ${protected_parent} && ! -L ${protected_parent} ]] ||
     fail "A release parent is missing or unsafe."
   chown root:root "${protected_parent}"
-  chmod 0755 "${protected_parent}"
+  chmod 00755 "${protected_parent}"
   [[ $(stat -c '%U:%G:%a' "${protected_parent}") == root:root:755 ]] ||
     fail "A release parent could not be protected from the service account."
 done
@@ -721,13 +721,13 @@ else
   install -d -o matsci-sam -g matsci-sam -m 0750 "${runtime_cache}"
 fi
 chown -hR matsci-sam:matsci-sam "${runtime_cache}"
-find "${runtime_cache}" -xdev -type d -exec chmod 0750 {} +
+find "${runtime_cache}" -xdev -type d -exec chmod 00750 {} +
 find "${runtime_cache}" -xdev -type f -exec chmod 0640 {} +
 ln -s "${runtime_cache}" "${release}/.next/cache"
 
 echo "Freezing the built release and recording its deterministic artifact manifest."
 chown -hR root:root "${release}"
-find "${release}" -xdev -type d -exec chmod 0555 {} +
+find "${release}" -xdev -type d -exec chmod 00555 {} +
 find "${release}" -xdev -type f -perm /111 -exec chmod 0555 {} +
 find "${release}" -xdev -type f ! -perm /111 -exec chmod 0444 {} +
 artifact_manifest_partial=${root_work}/release-artifacts

--- a/scripts/test-deployment-contract.ts
+++ b/scripts/test-deployment-contract.ts
@@ -1011,7 +1011,11 @@ assert.match(
 )
 assert.match(
   egoReleaseRemote,
-  /chown -hR root:root "\$\{release\}"[\s\S]*find "\$\{release\}" -xdev -type d -exec chmod 0555[\s\S]*find "\$\{release\}" -xdev -type f ! -perm \/111 -exec chmod 0444/
+  /chown -hR root:root "\$\{release\}"[\s\S]*find "\$\{release\}" -xdev -type d -exec chmod 00555[\s\S]*find "\$\{release\}" -xdev -type f ! -perm \/111 -exec chmod 0444/
+)
+assert.match(
+  egoReleaseRemote,
+  /find "\$\{runtime_cache\}" -xdev -type d -exec chmod 00750/
 )
 assert.match(
   egoReleaseRemote,
@@ -1019,7 +1023,7 @@ assert.match(
 )
 assert.match(
   egoReleaseRemote,
-  /for protected_parent in "\$\{app_root\}" "\$\{app_root\}\/releases"[\s\S]*chown root:root "\$\{protected_parent\}"[\s\S]*chmod 0755 "\$\{protected_parent\}"/
+  /for protected_parent in "\$\{app_root\}" "\$\{app_root\}\/releases"[\s\S]*chown root:root "\$\{protected_parent\}"[\s\S]*chmod 00755 "\$\{protected_parent\}"/
 )
 assert.match(egoReleaseRemote, /public_mode=maintenance/)
 


### PR DESCRIPTION
The fourth Ego operation attempt (the first pre-cutover release) failed at
"A release parent could not be protected from the service account" before
creating any release, backup, or database change; public maintenance stayed
active.

Root cause: Ego provisioning created `/opt/matsci-sam`, `releases/`, and
`shared/` with mode `2775`. GNU chmod preserves a directory's setuid/setgid
bits for four-digit numeric modes, so the helper's `chmod 0755` left the
parents at `2755` and the exact `root:root:755` stat check failed. Verified
empirically on GNU coreutils 9.4: `chmod 0755` on a `2775` directory yields
`2755`; `chmod 00755` yields `755`.

Two further latent instances would have failed later in the same run or at
cutover: the release root is deliberately `2770` during the build (and
extracted subdirectories inherit setgid from it), so the freeze's
`chmod 0555` could never have produced the `555` directories the artifact
manifest and the cutover check require; likewise the runtime-cache sweep's
`chmod 0750` versus the cutover's `matsci-sam:matsci-sam:750` check.

This changes only `deploy/lib/deploy-ego-precutover-remote.sh` (three
five-digit modes) and pins them in `scripts/test-deployment-contract.ts`.
Both paths are on the reviewed operations-only allowlist; the Superego
in-place helper is intentionally untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)