### PR TITLE
Promote Ego release setgid fix to main

### DIFF
--- a/deploy/lib/deploy-ego-precutover-remote.sh
+++ b/deploy/lib/deploy-ego-precutover-remote.sh
@@ -533,7 +533,7 @@ for protected_parent in "${app_root}" "${app_root}/releases"; do
   [[ -d ${protected_parent} && ! -L ${protected_parent} ]] ||
     fail "A release parent is missing or unsafe."
   chown root:root "${protected_parent}"
-  chmod 0755 "${protected_parent}"
+  chmod 00755 "${protected_parent}"
   [[ $(stat -c '%U:%G:%a' "${protected_parent}") == root:root:755 ]] ||
     fail "A release parent could not be protected from the service account."
 done
@@ -721,13 +721,13 @@ else
   install -d -o matsci-sam -g matsci-sam -m 0750 "${runtime_cache}"
 fi
 chown -hR matsci-sam:matsci-sam "${runtime_cache}"
-find "${runtime_cache}" -xdev -type d -exec chmod 0750 {} +
+find "${runtime_cache}" -xdev -type d -exec chmod 00750 {} +
 find "${runtime_cache}" -xdev -type f -exec chmod 0640 {} +
 ln -s "${runtime_cache}" "${release}/.next/cache"
 
 echo "Freezing the built release and recording its deterministic artifact manifest."
 chown -hR root:root "${release}"
-find "${release}" -xdev -type d -exec chmod 0555 {} +
+find "${release}" -xdev -type d -exec chmod 00555 {} +
 find "${release}" -xdev -type f -perm /111 -exec chmod 0555 {} +
 find "${release}" -xdev -type f ! -perm /111 -exec chmod 0444 {} +
 artifact_manifest_partial=${root_work}/release-artifacts

--- a/scripts/test-deployment-contract.ts
+++ b/scripts/test-deployment-contract.ts
@@ -1011,7 +1011,11 @@ assert.match(
 )
 assert.match(
   egoReleaseRemote,
-  /chown -hR root:root "\$\{release\}"[\s\S]*find "\$\{release\}" -xdev -type d -exec chmod 0555[\s\S]*find "\$\{release\}" -xdev -type f ! -perm \/111 -exec chmod 0444/
+  /chown -hR root:root "\$\{release\}"[\s\S]*find "\$\{release\}" -xdev -type d -exec chmod 00555[\s\S]*find "\$\{release\}" -xdev -type f ! -perm \/111 -exec chmod 0444/
+)
+assert.match(
+  egoReleaseRemote,
+  /find "\$\{runtime_cache\}" -xdev -type d -exec chmod 00750/
 )
 assert.match(
   egoReleaseRemote,
@@ -1019,7 +1023,7 @@ assert.match(
 )
 assert.match(
   egoReleaseRemote,
-  /for protected_parent in "\$\{app_root\}" "\$\{app_root\}\/releases"[\s\S]*chown root:root "\$\{protected_parent\}"[\s\S]*chmod 0755 "\$\{protected_parent\}"/
+  /for protected_parent in "\$\{app_root\}" "\$\{app_root\}\/releases"[\s\S]*chown root:root "\$\{protected_parent\}"[\s\S]*chmod 00755 "\$\{protected_parent\}"/
 )
 assert.match(egoReleaseRemote, /public_mode=maintenance/)
 


### PR DESCRIPTION
Promote reviewed `dev` to `main` so both branches carry the exact tree the
Ego pre-cutover source validation requires.

The delta is PR #28: five-digit chmod modes at the pre-cutover helper's three
directory-normalization points, so GNU chmod actually clears the setgid bits
inherited from Ego's 2775 provisioning modes, with the cleared modes pinned
in the deployment contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)