### PR TITLE
Allow reviewed .gitignore in the public-content contract

### DIFF
--- a/deploy/lib/verify-superego-public-content.sh
+++ b/deploy/lib/verify-superego-public-content.sh
@@ -40,6 +40,7 @@ operations_only_paths=(
   .agents/skills/manage-matsci-environments/references/environments.md
   .agents/skills/manage-matsci-environments/scripts/status.sh
   .github/workflows/pr-verify.yml
+  .gitignore
   README.md
   developing.md
   deploy/README.md

--- a/scripts/test-deployment-contract.ts
+++ b/scripts/test-deployment-contract.ts
@@ -59,6 +59,7 @@ const expectedOperationsOnlyPaths = [
   ".agents/skills/manage-matsci-environments/references/environments.md",
   ".agents/skills/manage-matsci-environments/scripts/status.sh",
   ".github/workflows/pr-verify.yml",
+  ".gitignore",
   "README.md",
   "developing.md",
   "deploy/README.md",


### PR DESCRIPTION
PR #32 untracked `.agents`, which required a `.gitignore` entry — but
`.gitignore` itself was not on the reviewed operations-only allowlist, so the
promoted candidate reported "changes content not validated on Superego" and
would have blocked the next Ego deployment.

`.gitignore` has no effect on the built application, its schema, its
migrations, or its runtime configuration, so it belongs with the other
non-runtime operations paths. Verified locally: with this entry the
equivalence check returns to `reviewed-operations-only`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)