### PR TITLE
Promote .gitignore allowlist correction

### DIFF
--- a/deploy/lib/verify-superego-public-content.sh
+++ b/deploy/lib/verify-superego-public-content.sh
@@ -40,6 +40,7 @@ operations_only_paths=(
   .agents/skills/manage-matsci-environments/references/environments.md
   .agents/skills/manage-matsci-environments/scripts/status.sh
   .github/workflows/pr-verify.yml
+  .gitignore
   README.md
   developing.md
   deploy/README.md

--- a/scripts/test-deployment-contract.ts
+++ b/scripts/test-deployment-contract.ts
@@ -59,6 +59,7 @@ const expectedOperationsOnlyPaths = [
   ".agents/skills/manage-matsci-environments/references/environments.md",
   ".agents/skills/manage-matsci-environments/scripts/status.sh",
   ".github/workflows/pr-verify.yml",
+  ".gitignore",
   "README.md",
   "developing.md",
   "deploy/README.md",


### PR DESCRIPTION
Promote reviewed `dev` to `main` so both branches carry the exact tree the
Ego deployment source validation requires.

The delta is PR #34: `.gitignore` joins the reviewed operations-only
allowlist, restoring `reviewed-operations-only` equivalence after the
`.agents` untracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)