### PR TITLE
Record Ego live status in the installed host rules

### DIFF
--- a/deploy/ego/AGENTS.md
+++ b/deploy/ego/AGENTS.md
@@ -15,31 +15,50 @@ at `ego.cci.drexel.edu`.
 
 Run `$manage-matsci-environments` and inspect live state before acting.
 
+## Status
+
+Ego has been the **live public site** since 2026-07-26. Its database is
+seeded and independently authoritative (`DATA-AUTHORITY` records `ego`), the
+application service is active and boot-enabled, and Nginx serves the
+application rather than the maintenance page. The public cutover was performed
+manually by the operator after two fail-closed wrapper attempts, so **no
+cutover marker exists on this host** and the active site file has not been
+machine-verified against reviewed source since. Confirm the effective
+configuration by inspection before any edge change.
+
+**There is no supported later-release procedure.**
+`deploy/deploy-ego-from-workstation.sh` refuses unless Ego has no release and
+an inactive, disabled service, and `deploy/cutover-ego-public.sh` refuses
+unless the service is disabled and the installed release directory name embeds
+the current `origin/main` commit — a condition the cutover's own
+`systemctl enable` permanently invalidated. Until a reviewed in-place,
+database-aware Ego release operation exists, do not improvise one on this
+host. To restore service quickly, roll back rather than deploy forward: the
+maintenance configuration is retained root-only under `/root`, and its
+reviewed bytes are tracked as
+`deploy/nginx/matsci-sam-public-maintenance.conf`.
+
 ## Rules
 
-- Keep the HTTPS maintenance configuration active until an approved public
-  release, database seed, OAuth configuration, and cutover have passed.
+- Before any public-edge change, capture the complete effective Nginx
+  configuration, keep a root-only backup, validate with `nginx -t`, reload,
+  and check the public contract. Restore the retained maintenance
+  configuration from that backup if any post-change check fails.
 - Never edit `/opt/matsci-sam/current` or a release directory in place.
 - Never print or copy `/etc/matsci-sam/app.env`, database credentials, OAuth
   secrets, session secrets, authentication tokens, or TLS private keys.
-- The initial `DATA-AUTHORITY` value is `uninitialized`. A reviewed one-time
-  seed through `deploy/seed-ego-from-superego.sh` may change it to `ego`.
-  After that change, never replace or refresh the Ego database from Superego.
-- Run the one-time seed, first pre-cutover release, and public cutover only
-  from the recorded control workstation. Do not invoke files under
-  `deploy/lib/` directly.
+- `DATA-AUTHORITY` records `ego`. The one-time seed ran on 2026-07-25 and can
+  never run again. Never replace or refresh the Ego database from Superego.
+- Run any Ego operation only from the recorded control workstation. Do not
+  invoke files under `deploy/lib/` directly.
 - Promoted `origin/main` must exactly match reviewed `origin/dev`. Application,
   schema, migration, dependency, build, service, and runtime-configuration
   content must already be validated on Superego; only the exact reviewed
   non-runtime allowlist may differ.
-- `deploy/deploy-ego-from-workstation.sh` prepares only the first release
-  after the seed. It verifies the Ego-authoritative database, builds under the
-  protected public environment, starts the application on loopback, and keeps
-  maintenance active. Do not reuse it for a later in-place release.
-- `deploy/cutover-ego-public.sh` is the separate public-edge operation. Run it
-  only after the pre-cutover marker exists and the user gives separate
-  approval. It backs up and validates Nginx, tests the public contract, and
-  restores maintenance after an activation failure.
+- `deploy/deploy-ego-from-workstation.sh` and `deploy/cutover-ego-public.sh`
+  both completed their one-time purpose and now refuse to run against this
+  host, by their own preconditions. They are retained as the record of how
+  this release was produced. Neither is a redeployment path.
 - Keep PostgreSQL and the Next.js listener local to Ego. PostgreSQL uses the
   Unix socket, and Next.js listens only on `127.0.0.1:3000`.
 - Inspect the complete effective Nginx configuration before a change. Back up


### PR DESCRIPTION
`deploy/ego/AGENTS.md` is checksummed by the provisioning helper and installed
on Ego as that host's operating rules. Its first rule still said to keep the
HTTPS maintenance configuration active until a cutover passed — wrong since
the site went public on 2026-07-26, and the most misleading text an operator
would read on the live host.

Now records: Ego is live and boot-enabled with an independently authoritative
database; the cutover was manual, so no marker exists and the active site file
has not been machine-verified against reviewed source since; and there is no
supported later-release path, because `deploy-ego-from-workstation.sh` requires
no existing release with an inactive service while `cutover-ego-public.sh`
requires a disabled service — a condition its own `systemctl enable`
permanently invalidated. Directs anyone needing to restore service to roll back
using the retained root-only maintenance backup rather than improvise a deploy.

Documentation only; the file is on the reviewed operations-only allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)