### PR TITLE
Retire the dev-to-main promotion for Ego operations

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -183,17 +183,30 @@ workflow and its self-hosted runner have been retired.
 The release path is:
 
 ```text
-reviewed origin/dev -> Superego validation
-exact reviewed dev tree -> origin/main -> Ego
+reviewed origin/dev -> Superego -> Ego
 ```
 
-The main commit may differ from the validated dev commit when GitHub creates a
-merge commit. `origin/main` and `origin/dev` must have the same exact tree.
-Application, schema, migration, dependency, build, service, and runtime
-configuration content must match the Superego-validated release; only the
-explicit reviewed non-runtime allowlist may differ. Ego builds the promoted
-tree again with the public environment because
+`origin/dev` is the single reviewed branch. The commit deployed to Ego must be
+the commit Superego already runs, so public content is content the private
+runtime ran first. That is one exact commit comparison: Superego records its
+deployed commit in its release directory name, and the Ego wrappers require
+equality with the reviewed commit.
+
+Ego builds the reviewed tree again with the public environment because
 `NEXT_PUBLIC_SITE_URL` is build-time configuration.
+
+Shipping a reviewed commit that Superego has not deployed — an operations-only
+correction, for example — requires the explicit `--allow-undeployed` flag,
+which records `superego_validation=undeployed-operator-override` in the
+release manifest. It is a deliberate, recorded exception rather than a
+routine path.
+
+There is no promotion branch. The previous design required every change to be
+promoted from `dev` to `main` on an identical tree and compared against a
+maintained allowlist of non-runtime paths. That produced two pull requests and
+two continuous-integration runs per change, made the file that validates
+deployment tooling a member of its own allowlist, and stranded a verified Ego
+release on 2026-07-26 when a promoted operations-only fix moved `origin/main`.
 
 When both authority records identify Superego as the shared-data authority,
 run this from the recorded control workstation:

--- a/deploy/cutover-ego-public.sh
+++ b/deploy/cutover-ego-public.sh
@@ -182,6 +182,8 @@ state_authority=$(
 
 origin_url=$(git -C "${repo}" remote get-url origin)
 case ${origin_url} in
+  https://github.com/metadata-research/matsci-sam.git|\
+  git@github.com:metadata-research/matsci-sam.git|\
   https://github.com/metadata-research/matsci-yamz.git|\
   git@github.com:metadata-research/matsci-yamz.git)
     ;;
@@ -190,7 +192,7 @@ case ${origin_url} in
     ;;
 esac
 
-git -C "${repo}" fetch --prune origin dev main
+git -C "${repo}" fetch --prune origin dev
 branch=$(git -C "${repo}" branch --show-current)
 [[ ${branch} == dev ]] ||
   fail "The control-workstation checkout must remain on dev."
@@ -202,14 +204,11 @@ fi
 origin_dev=$(git -C "${repo}" rev-parse refs/remotes/origin/dev)
 [[ $(git -C "${repo}" rev-parse HEAD) == "${origin_dev}" ]] ||
   fail "HEAD and origin/dev must identify the same reviewed commit."
-expected_commit=$(git -C "${repo}" rev-parse refs/remotes/origin/main)
+expected_commit=${origin_dev}
 expected_tree=$(git -C "${repo}" rev-parse "${expected_commit}^{tree}")
-dev_tree=$(git -C "${repo}" rev-parse "${origin_dev}^{tree}")
 [[ ${expected_commit} =~ ^[0-9a-f]{40}$ &&
   ${expected_tree} =~ ^[0-9a-f]{40}$ ]] ||
-  fail "The promoted public source ref is invalid."
-[[ ${dev_tree} == "${expected_tree}" ]] ||
-  fail "origin/main is not the exact reviewed origin/dev tree."
+  fail "The reviewed source ref is invalid."
 verify_reviewed_worktree "${expected_commit}"
 
 maintenance_sha=$(sha256sum "${maintenance_config}" | awk '{print $1}')
@@ -288,11 +287,10 @@ IFS= read -r confirmation
 [[ ${confirmation} == "CUT OVER EGO PUBLIC" ]] ||
   fail "Public cutover cancelled."
 
-git -C "${repo}" fetch --prune origin dev main
+git -C "${repo}" fetch --prune origin dev
 [[ -z $(git -C "${repo}" status --porcelain=v1) &&
   $(git -C "${repo}" rev-parse HEAD) == "${origin_dev}" &&
   $(git -C "${repo}" rev-parse refs/remotes/origin/dev) == "${origin_dev}" &&
-  $(git -C "${repo}" rev-parse refs/remotes/origin/main) == "${expected_commit}" &&
   $(git -C "${repo}" rev-parse "${expected_commit}^{tree}") == "${expected_tree}" ]] ||
   fail "Reviewed source changed during the public-cutover checks."
 verify_reviewed_worktree "${expected_commit}"

--- a/deploy/deploy-ego-from-workstation.sh
+++ b/deploy/deploy-ego-from-workstation.sh
@@ -35,6 +35,7 @@ state_file=${repo}/docs-internal/CURRENT-DEV-STATE.md
 workstation_registry=${script_dir}/workstations.tsv
 check_only=false
 yes_deploy=false
+allow_undeployed=false
 remote_staged=false
 remote_dir=
 work_dir=
@@ -43,17 +44,22 @@ usage() {
   cat <<'USAGE'
 Usage: deploy/deploy-ego-from-workstation.sh [options]
 
-Prepare the first promoted origin/main release on Ego after its one-time
-public seed. The operation verifies and backs up the already-current
+Prepare the reviewed origin/dev release on Ego after its one-time public
+seed. The operation verifies and backs up the already-current
 Ego-authoritative database, builds under Ego's protected public environment,
 starts the application on loopback, and leaves public Nginx maintenance
 unchanged. After this succeeds, deploy/cutover-ego-public.sh performs the
 separately approved public-edge activation.
 
+The reviewed commit must already be the commit deployed on Superego, so that
+public content is content that ran on the private runtime first. Shipping a
+commit Superego has not run requires the explicit override below.
+
 Options:
-  --yes-deploy  Skip the deployment confirmation prompt
-  --check-only  Validate source, authority, and the release artifact locally
-  -h, --help    Show this help
+  --yes-deploy         Skip the deployment confirmation prompt
+  --check-only         Validate source, authority, and the release artifact
+  --allow-undeployed   Permit a reviewed commit Superego has not deployed
+  -h, --help           Show this help
 USAGE
 }
 
@@ -127,6 +133,10 @@ while (($#)); do
       check_only=true
       shift
       ;;
+    --allow-undeployed)
+      allow_undeployed=true
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -195,6 +205,8 @@ remote_authority=$(
 
 origin_url=$(git -C "${repo}" remote get-url origin)
 case ${origin_url} in
+  https://github.com/metadata-research/matsci-sam.git|\
+  git@github.com:metadata-research/matsci-sam.git|\
   https://github.com/metadata-research/matsci-yamz.git|\
   git@github.com:metadata-research/matsci-yamz.git)
     ;;
@@ -203,7 +215,7 @@ case ${origin_url} in
     ;;
 esac
 
-git -C "${repo}" fetch --prune origin dev main
+git -C "${repo}" fetch --prune origin dev
 branch=$(git -C "${repo}" branch --show-current)
 [[ ${branch} == dev ]] ||
   fail "The control-workstation checkout must remain on dev."
@@ -214,11 +226,8 @@ fi
 origin_dev=$(git -C "${repo}" rev-parse refs/remotes/origin/dev)
 [[ $(git -C "${repo}" rev-parse HEAD) == "${origin_dev}" ]] ||
   fail "HEAD and origin/dev must identify the same reviewed commit."
-candidate=$(git -C "${repo}" rev-parse refs/remotes/origin/main)
+candidate=${origin_dev}
 candidate_tree=$(git -C "${repo}" rev-parse "${candidate}^{tree}")
-dev_tree=$(git -C "${repo}" rev-parse "${origin_dev}^{tree}")
-[[ ${candidate_tree} == "${dev_tree}" ]] ||
-  fail "origin/main does not contain the exact reviewed origin/dev tree."
 verify_reviewed_worktree "${candidate}"
 
 superego_release=$(
@@ -234,12 +243,15 @@ superego_commit=${superego_name:0:40}
 git -C "${repo}" cat-file -e "${superego_commit}^{commit}" 2>/dev/null ||
   fail "The active Superego commit is not present in local Git history."
 superego_tree=$(git -C "${repo}" rev-parse "${superego_commit}^{tree}")
-superego_validation=$(
-  "${superego_content_verifier}" \
-    "${repo}" \
-    "${superego_commit}" \
-    "${candidate}"
-) || fail "The public application content is not the content validated on Superego."
+if [[ ${superego_commit} == "${candidate}" ]]; then
+  superego_validation=deployed-on-superego
+elif [[ ${allow_undeployed} == true ]]; then
+  superego_validation=undeployed-operator-override
+else
+  echo "Reviewed commit:   ${candidate}" >&2
+  echo "Superego runs:     ${superego_commit}" >&2
+  fail "This commit is not the one deployed on Superego. Deploy it there first, or rerun with --allow-undeployed."
+fi
 
 ego_release_state=$(
   ssh -o BatchMode=yes ego '
@@ -270,17 +282,16 @@ echo "Checking source, authentication plumbing, deployment contracts, and migrat
   pnpm db:check
 )
 
-git -C "${repo}" fetch --prune origin dev main
+git -C "${repo}" fetch --prune origin dev
 if [[ -n $(git -C "${repo}" status --porcelain=v1) ]]; then
   git -C "${repo}" status --short >&2
   fail "The worktree changed during deployment preparation."
 fi
 [[ $(git -C "${repo}" rev-parse HEAD) == "${origin_dev}" &&
-  $(git -C "${repo}" rev-parse refs/remotes/origin/dev) == "${origin_dev}" &&
-  $(git -C "${repo}" rev-parse refs/remotes/origin/main) == "${candidate}" ]] ||
+  $(git -C "${repo}" rev-parse refs/remotes/origin/dev) == "${origin_dev}" ]] ||
   fail "A reviewed source ref changed during deployment preparation."
 [[ $(git -C "${repo}" rev-parse "${candidate}^{tree}") == "${candidate_tree}" ]] ||
-  fail "The promoted public tree changed during deployment preparation."
+  fail "The reviewed tree changed during deployment preparation."
 verify_reviewed_worktree "${candidate}"
 
 work_dir=$(mktemp -d)
@@ -306,7 +317,7 @@ archive_sha=$(sha256sum "${archive}" | awk '{print $1}')
     "$(sha256sum "${local_candidate}" | awk '{print $1}')"
 } >"${manifest}"
 
-printf 'Validated Ego pre-cutover artifact for origin/main commit %s.\n' \
+printf 'Validated Ego pre-cutover artifact for reviewed commit %s.\n' \
   "${candidate}"
 printf 'validated_superego_commit=%s\n' "${superego_commit}"
 printf 'validated_superego_tree=%s\n' "${superego_tree}"

--- a/deploy/deploy-superego-from-workstation.sh
+++ b/deploy/deploy-superego-from-workstation.sh
@@ -134,6 +134,8 @@ remote_authority=$(
 
 origin_url=$(git -C "${repo}" remote get-url origin)
 case ${origin_url} in
+  https://github.com/metadata-research/matsci-sam.git|\
+  git@github.com:metadata-research/matsci-sam.git|\
   https://github.com/metadata-research/matsci-yamz.git|\
   git@github.com:metadata-research/matsci-yamz.git)
     ;;

--- a/deploy/provision-ego-runtime.sh
+++ b/deploy/provision-ego-runtime.sh
@@ -149,6 +149,8 @@ esac
 
 origin_url=$(git -C "${repo}" remote get-url origin)
 case ${origin_url} in
+  https://github.com/metadata-research/matsci-sam.git|\
+  git@github.com:metadata-research/matsci-sam.git|\
   https://github.com/metadata-research/matsci-yamz.git|\
   git@github.com:metadata-research/matsci-yamz.git)
     ;;

--- a/deploy/pull-superego-db-to-workstation.sh
+++ b/deploy/pull-superego-db-to-workstation.sh
@@ -326,6 +326,8 @@ ssh -o BatchMode=yes -o ConnectTimeout=8 superego '
 
 origin_url=$(git -C "${repo}" remote get-url origin)
 case ${origin_url} in
+  https://github.com/metadata-research/matsci-sam.git|\
+  git@github.com:metadata-research/matsci-sam.git|\
   https://github.com/metadata-research/matsci-yamz.git|\
   git@github.com:metadata-research/matsci-yamz.git)
     ;;

--- a/deploy/reset-superego-from-pa90.sh
+++ b/deploy/reset-superego-from-pa90.sh
@@ -132,6 +132,8 @@ state_authority=$(
 }
 origin_url=$(git -C "${repo}" remote get-url origin)
 case ${origin_url} in
+  https://github.com/metadata-research/matsci-sam.git|\
+  git@github.com:metadata-research/matsci-sam.git|\
   https://github.com/metadata-research/matsci-yamz.git|\
   git@github.com:metadata-research/matsci-yamz.git)
     ;;

--- a/deploy/seed-ego-from-superego.sh
+++ b/deploy/seed-ego-from-superego.sh
@@ -303,6 +303,8 @@ flock --nonblock 8 ||
 
 origin_url=$(git -C "${repo}" remote get-url origin)
 case ${origin_url} in
+  https://github.com/metadata-research/matsci-sam.git|\
+  git@github.com:metadata-research/matsci-sam.git|\
   https://github.com/metadata-research/matsci-yamz.git|\
   git@github.com:metadata-research/matsci-yamz.git)
     ;;

--- a/scripts/test-deployment-contract.ts
+++ b/scripts/test-deployment-contract.ts
@@ -899,18 +899,21 @@ for (const [name, remote] of [
 
 assert.match(egoReleaseWrapper, /state_authority} == ego/)
 assert.match(egoReleaseWrapper, /remote_authority} == ego/)
+// The public candidate is the reviewed commit itself: no promotion branch,
+// no tree diffing, no path allowlist. Superego equivalence is exact commit
+// equality, and shipping a commit Superego has not run is an explicit,
+// recorded operator override.
+assert.doesNotMatch(egoReleaseWrapper, /refs\/remotes\/origin\/main/)
+assert.match(egoReleaseWrapper, /candidate=\$\{origin_dev\}/)
 assert.match(
   egoReleaseWrapper,
-  /superego_content_verifier[\s\S]*superego_commit[\s\S]*candidate/
-)
-assert.doesNotMatch(
-  egoReleaseWrapper,
-  /candidate_tree} == "\$\{superego_tree\}"/
+  /\[\[ \$\{superego_commit\} == "\$\{candidate\}" \]\][\s\S]*superego_validation=deployed-on-superego/
 )
 assert.match(
   egoReleaseWrapper,
-  /candidate_tree} == "\$\{dev_tree\}"/
+  /allow_undeployed} == true[\s\S]*superego_validation=undeployed-operator-override/
 )
+assert.match(egoReleaseWrapper, /--allow-undeployed/)
 assert.match(
   egoReleaseWrapper,
   /superego_content_verifier}"[\s\S]*--create-archive[\s\S]*candidate/
@@ -1030,6 +1033,8 @@ assert.match(
 )
 assert.match(egoReleaseRemote, /public_mode=maintenance/)
 
+assert.doesNotMatch(egoCutoverWrapper, /refs\/remotes\/origin\/main/)
+assert.match(egoCutoverWrapper, /expected_commit=\$\{origin_dev\}/)
 assert.match(
   egoCutoverWrapper,
   /Type CUT OVER EGO PUBLIC to continue/


### PR DESCRIPTION
Removes the two-pull-request ceremony. `origin/dev` becomes the single reviewed
branch.

**What it replaces.** The Ego wrappers required `origin/main` and `origin/dev`
to carry an identical tree, then diffed the candidate against the
Superego-deployed commit while excluding a maintained 20-path allowlist of
non-runtime files. Every change therefore needed two PRs and two CI runs.

**Why it cost more than it protected.** `verify-superego-public-content.sh` is
itself on its own allowlist, so changing deployment tooling meant editing the
allowlist in two places (the script and its mirror in the contract test) and
promoting it. Three of tonight's PRs existed only to feed that mechanism. Worse,
promoting an operations-only fix moved `origin/main` and **stranded the verified
Ego release**, because the cutover preflight binds the installed release
directory name to the current `main` commit.

**What preserves the guarantee.** "Public content ran on the private runtime
first" is now one exact comparison: the reviewed commit must equal the commit
Superego actually deploys, which Superego already records in its release
directory name. No tree diffing, no path list. Stronger than the allowlist
version, which permitted a whole class of differences by construction.

**Escape hatch.** `--allow-undeployed` permits a reviewed commit Superego has
not run, recording `superego_validation=undeployed-operator-override` in the
release manifest — a deliberate, auditable exception rather than an invitation
to edit a path list.

**Not touched.** The seed wrapper keeps its original gates; it completed its
one-time operation, can never run again, and stands as the record of how the
public database was initialized. The Superego deployment path never referenced
`origin/main` at all and is unchanged.

**Also folded in:** every wrapper accepted only the former `matsci-yamz` remote
URL, but the repository is now `matsci-sam` — a fresh clone would have been
refused by all 14 origin checks. Both names are accepted.

Cannot affect the running site: the live release is a frozen directory behind a
symlink, and these are workstation-side source checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)