### PR TITLE
Preserve the author's example of use through AI refinement

### DIFF
--- a/components/definition/refine-panel.tsx
+++ b/components/definition/refine-panel.tsx
@@ -166,13 +166,29 @@ export const RefinePanel = ({
                 </div>
               </CardContent>
               <CardFooter className="flex-col items-stretch gap-2">
-                <div className="flex gap-2">
+                <div className="flex flex-wrap gap-2">
                   <Button
                     disabled={busy}
                     onClick={() => accept.mutate({ refinementId: round.id })}
                   >
                     <CheckIcon className="size-4 mr-1" /> Accept suggestion
                   </Button>
+                  {round.suggestedExample?.trim() !==
+                    current.example.trim() && (
+                    <Button
+                      variant="secondary"
+                      disabled={busy}
+                      onClick={() =>
+                        accept.mutate({
+                          refinementId: round.id,
+                          keepExample: true
+                        })
+                      }
+                    >
+                      <CheckIcon className="size-4 mr-1" /> Accept definition,
+                      keep my example
+                    </Button>
+                  )}
                   <Button
                     variant="outline"
                     disabled={busy}

--- a/lib/prompts.json
+++ b/lib/prompts.json
@@ -8,7 +8,7 @@
     "prompt": "You are to define material science terms. Keep definitions concise and don't be conversational, just respond with a definition and an example using the term with the given definition."
   },
   "refine": {
-    "description": "Reviews a user-authored definition and suggests an improved revision, used by the interactive refine flow.",
-    "prompt": "You are a materials science editor reviewing a user's draft definition of a term. Improve the draft: keep the user's intent and any correct content, but make the definition precise, concise, and consistent with how the term is used in the materials science literature. Correct factual errors. Return a revised definition and one example sentence using the term; improve the user's example if it is weak, or keep its substance if it is good. If the user gives feedback on your previous suggestion, revise your suggestion to address that feedback while keeping the definition technically accurate."
+    "description": "Reviews a user-authored definition and suggests an improved revision, used by the interactive refine flow. Preserves the author's example unless it is defective.",
+    "prompt": "You are a materials science editor reviewing a user's draft definition of a term. Improve the draft: keep the user's intent and any correct content, but make the definition precise, concise, and consistent with how the term is used in the materials science literature. Correct factual errors. Return the author's example sentence back verbatim. Replace it only if it is factually wrong, does not use the term, or does not illustrate the definition; if you replace it, begin the example with a short bracketed reason such as [replaced: the original example did not use the term]. Do not reword an example merely to restyle it. If the user gives feedback on your previous suggestion, revise your suggestion to address that feedback while keeping the definition technically accurate."
   }
 }

--- a/trpc/routers/refinements.ts
+++ b/trpc/routers/refinements.ts
@@ -146,8 +146,17 @@ export const refinementsRouter = createTRPCRouter({
     ),
 
   accept: authenticatedProcedure
-    .input(z.object({ refinementId: z.number() }))
-    .mutation(async ({ ctx: { userId }, input: { refinementId } }) => {
+    .input(
+      z.object({
+        refinementId: z.number(),
+        // Accept the revised definition but keep the author's own example of
+        // use. The model earns joint credit for the definition either way;
+        // the example stays the author's work.
+        keepExample: z.boolean().optional()
+      })
+    )
+    .mutation(async ({ ctx: { userId }, input }) => {
+      const { refinementId, keepExample } = input
       const preview = await db.query.refinementsTable.findFirst({
         where: eq(refinementsTable.id, refinementId)
       })
@@ -216,6 +225,17 @@ export const refinementsRouter = createTRPCRouter({
           .set({ status: "accepted", decidedAt: sql`now()` })
           .where(eq(refinementsTable.id, round.id))
 
+        // A round is only acceptable while the definition still sits on its
+        // source revision, so the author's current example is exactly the one
+        // the model was shown.
+        const keptExample = keepExample && original.example?.trim()
+        const acceptedExample = keptExample
+          ? original.example!
+          : round.suggestedExample!
+        const acceptedChangeNote = keptExample
+          ? `Accepted AI refinement round ${round.round}, keeping the author's example`
+          : `Accepted AI refinement round ${round.round}`
+
         // One refined definition per original: later acceptances update it
         // through the edit path so the revision history stays derivable.
         const existing = await tx.query.definitionsTable.findFirst({
@@ -239,8 +259,8 @@ export const refinementsRouter = createTRPCRouter({
                 definitionId: existing.id,
                 editorId: userId,
                 definition: round.suggestedDefinition!,
-                example: round.suggestedExample!,
-                changeNote: `Accepted AI refinement round ${round.round}`,
+                example: acceptedExample,
+                changeNote: acceptedChangeNote,
                 source: "ai_refinement",
                 expectedRevisionId: existing.currentRevisionId ?? undefined,
                 model: round.model,
@@ -278,8 +298,8 @@ export const refinementsRouter = createTRPCRouter({
             termId: original.termId,
             authorId: userId,
             definition: round.suggestedDefinition!,
-            example: round.suggestedExample!,
-            changeNote: `Accepted AI refinement round ${round.round}`,
+            example: acceptedExample,
+            changeNote: acceptedChangeNote,
             source: "ai_refinement",
             model: round.model,
             prompt: round.promptText,


### PR DESCRIPTION
The `refine` prompt invited the model to "improve the user's example if it is
weak", and models treat any latitude as licence to rewrite. On `yield strength`
a sound example came back as a blander paraphrase and the author's sentence
vanished from the refined definition.

Nothing was lost from the database — accepting a refinement creates a new
definition, so the original keeps its immutable revisions. What was lost was
the author's voice inside the definition that reads as canonical.

**Prompt.** The default is inverted: return the author's example verbatim, and
replace it only when it is factually wrong, does not use the term, or does not
illustrate the definition. A replacement must open with a short bracketed
reason, so substitutions are visible rather than silent.

**Interface.** A third control, *"Accept definition, keep my example"*, takes
the revised definition text and keeps the author's example, recording the
choice in the change note. It appears only when the suggested example actually
differs, so it stays out of the way when there is nothing to choose.

**Unchanged:** the `materials-reference` prompt still requires the model's
example to be its own — a separately attributed competing definition should
bring its own usage sentence. The defect was confined to the refine path.

## Verified locally against gemma4:26b

- Sound example (`ductility`) — returned **verbatim**; the new control
  correctly stayed hidden. Confirmed via the stored `promptText` that the new
  prompt was live.
- Defective example (`fracture toughness`, an example that never used the
  term) — replaced *with its reason stated*: `[replaced: the original example
  described toughness/ductility rather than the specific property of fracture
  toughness]`. The control appeared, and accepting through it stored the
  model's definition with the author's example and the change note
  "…keeping the author's example".

Lint, type-check, and all five test suites pass. No schema change; the
contract pins prompt keys rather than prompt text, so no deployment-contract
churn. The `promptHash` provenance stamp shifts by design, keeping past
generations attributable to the text that produced them.

A design note on supporting *multiple* examples with per-example attribution
is recorded in the private docs; it needs a schema change and is not proposed
here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)