### PR TITLE
fix(deploy): normalize release database names

### DIFF
--- a/deploy/lib/deploy-superego-in-place-remote.sh
+++ b/deploy/lib/deploy-superego-in-place-remote.sh
@@ -727,7 +727,7 @@ restore_database_backup() {
     return 1
   fi
 
-  displaced_database="matsci_${environment_slug}_rollback_old_${stamp}_$$"
+  displaced_database="matsci_${environment_slug}_rollback_old_${database_stamp}_$$"
   if [[ ! ${displaced_database} =~ ^[a-z][a-z0-9_]{0,62}$ ]]; then
     cleanup_scratch_database >/dev/null 2>&1 || true
     return 1
@@ -1130,8 +1130,11 @@ case ${nginx_initial_state} in
 esac
 
 stamp=$(date -u +%Y%m%dT%H%M%SZ)
+database_stamp=${stamp//[!0-9]/}
+[[ ${database_stamp} =~ ^[0-9]{14}$ ]] ||
+  fail "The database timestamp is malformed."
 backup=${backup_dir}/matsci-sam-${environment_slug}-before-release-${stamp}.dump
-scratch_database="matsci_${environment_slug}_release_check_${stamp}_$$"
+scratch_database="matsci_${environment_slug}_release_check_${database_stamp}_$$"
 
 if [[ -e ${admin_root} || -L ${admin_root} ]]; then
   [[ -d ${admin_root} && ! -L ${admin_root} &&

--- a/scripts/test-deployment-contract.ts
+++ b/scripts/test-deployment-contract.ts
@@ -860,6 +860,24 @@ assert.match(
   sharedDatabaseRestoreFunction[1],
   /if runuser -u postgres -- dropdb[\s\S]*then[\s\S]*scratch_database_created=false[\s\S]*else[\s\S]*failed restore database could not be removed/
 )
+assert.match(
+  repeatableReleaseRemote,
+  /database_stamp=\$\{stamp\/\/\[!0-9\]\/\}[\s\S]*scratch_database="matsci_\$\{environment_slug\}_release_check_\$\{database_stamp\}_\$\$"/
+)
+assert.match(
+  repeatableReleaseRemote,
+  /displaced_database="matsci_\$\{environment_slug\}_rollback_old_\$\{database_stamp\}_\$\$"/
+)
+for (const environment of ["superego", "ego"]) {
+  const databaseStamp = "20260728T075400Z".replaceAll(/\D/g, "")
+  for (const databaseName of [
+    `matsci_${environment}_release_check_${databaseStamp}_4194304`,
+    `matsci_${environment}_rollback_old_${databaseStamp}_4194304`
+  ]) {
+    assert.match(databaseName, /^[a-z][a-z0-9_]{0,62}$/)
+    assert(Buffer.byteLength(databaseName, "utf8") <= 63)
+  }
+}
 assert.equal(
   [...repeatableReleaseRemote.matchAll(/runuser -u postgres -- createdb/g)]
     .length,


### PR DESCRIPTION
## Summary

- derive a numeric database timestamp from the human-readable release timestamp
- use it for both online/frozen scratch restores and emergency rollback displacement
- retain the strict lowercase PostgreSQL identifier guard
- cover Superego and Ego names at Linux's maximum practical PID and PostgreSQL's 63-byte limit

## Failure reproduced

The first routine Superego release generated a name containing uppercase `T`
and `Z`, then correctly rejected it against the lowercase-only safety guard:

```text
Preparing and building the candidate while Superego remains available.
Refusing to create an unsafe database name.
```

The same raw timestamp was also present in the rollback database name. This
patch fixes both generators without broadening the allowlist.

The failed attempt left Superego on its prior healthy release with unchanged
44 users, 37 terms, 81 definitions, and 27 migrations. No candidate or user
staging remained.

## Verification

- `bash -n deploy/lib/deploy-superego-in-place-remote.sh`
- `pnpm test:deployment`
- `pnpm db:check`
- independent focused patch review

No seed, cross-host database copy, or live database replacement is involved.
