### PR TITLE
fix(deploy): accept legacy Ego source record

### DIFF
--- a/deploy/lib/deploy-superego-in-place-remote.sh
+++ b/deploy/lib/deploy-superego-in-place-remote.sh
@@ -69,6 +69,40 @@ fail() {
   exit 1
 }
 
+parse_previous_source_record() {
+  local source_record=$1
+  local record_target=$2
+  local source_record_size=$3
+  local current_record_re='^([0-9a-f]{40}) ([0-9a-f]{64})$'
+  local legacy_ego_record_re='^([0-9a-f]{40}) ([0-9a-f]{40}) ([0-9a-f]{40}) ([0-9a-f]{64})$'
+
+  recorded_previous_commit=
+  recorded_previous_sha=
+  recorded_previous_tree=
+  recorded_previous_validated_superego_commit=
+
+  if [[ ${source_record_size} == 106 &&
+    ${source_record} =~ ${current_record_re} ]]
+  then
+    recorded_previous_commit=${BASH_REMATCH[1]}
+    recorded_previous_sha=${BASH_REMATCH[2]}
+    return 0
+  fi
+
+  if [[ ${source_record_size} == 188 &&
+    ${record_target} == ego &&
+    ${source_record} =~ ${legacy_ego_record_re} ]]
+  then
+    recorded_previous_commit=${BASH_REMATCH[1]}
+    recorded_previous_tree=${BASH_REMATCH[2]}
+    recorded_previous_validated_superego_commit=${BASH_REMATCH[3]}
+    recorded_previous_sha=${BASH_REMATCH[4]}
+    return 0
+  fi
+
+  return 1
+}
+
 verify_redirect_headers() {
   local headers=$1
   local expected_status=$2
@@ -1201,23 +1235,25 @@ previous=$(readlink -e "${app_root}/current") ||
 [[ ${previous} == "${app_root}/releases/"* && -d ${previous} ]] ||
   fail "The current release is outside the release directory."
 previous_name=$(basename "${previous}")
-previous_commit=${previous_name:0:40}
-[[ ${previous_commit} =~ ^[0-9a-f]{40}$ ]] ||
+[[ ${previous_name} =~ ^([0-9a-f]{40})-([A-Za-z0-9]{8})$ ]] ||
   fail "The current release does not identify a source commit."
+previous_commit=${BASH_REMATCH[1]}
 previous_source_record=${previous}/.matsci-release-source
-if [[ ${previous_name} =~ ^[0-9a-f]{40}-[A-Za-z0-9]{8}$ ]]; then
-  [[ -f ${previous_source_record} && ! -L ${previous_source_record} &&
-    $(stat -c '%U' "${previous_source_record}") == root ]] ||
-    fail "The current release has no trusted source record."
-  IFS=' ' read -r recorded_previous_commit recorded_previous_sha extra \
-    <"${previous_source_record}"
-  [[ ${recorded_previous_commit} =~ ^[0-9a-f]{40}$ &&
-    ${recorded_previous_sha} =~ ^[0-9a-f]{64}$ &&
-    -z ${extra:-} ]] ||
-    fail "The current release source record is malformed."
-  [[ ${recorded_previous_commit} == "${previous_commit}" ]] ||
-    fail "The current release source record conflicts with its directory."
-fi
+[[ -f ${previous_source_record} && ! -L ${previous_source_record} &&
+  $(stat -c '%U' "${previous_source_record}") == root &&
+  -z $(find "${previous_source_record}" -maxdepth 0 -perm /022 -print -quit) ]] ||
+  fail "The current release has no trusted source record."
+[[ $(awk 'END { print NR }' "${previous_source_record}") == 1 ]] ||
+  fail "The current release source record is malformed."
+source_record_size=$(stat -c '%s' "${previous_source_record}")
+source_record=$(<"${previous_source_record}")
+parse_previous_source_record \
+  "${source_record}" \
+  "${target}" \
+  "${source_record_size}" ||
+  fail "The current release source record is malformed."
+[[ ${recorded_previous_commit} == "${previous_commit}" ]] ||
+  fail "The current release source record conflicts with its directory."
 [[ ${previous_commit} == "${manifest[previous_commit]}" ]] ||
   fail "${environment_name} changed after release preparation; start again."
 

--- a/scripts/test-deployment-contract.ts
+++ b/scripts/test-deployment-contract.ts
@@ -711,6 +711,192 @@ assert.match(
 const repeatableReleaseRemote = read(
   "deploy/lib/deploy-superego-in-place-remote.sh"
 )
+const previousSourceRecordParser = repeatableReleaseRemote.match(
+  /^parse_previous_source_record\(\) \{\n([\s\S]*?)^\}$/m
+)
+assert(
+  previousSourceRecordParser,
+  "Could not locate the previous-release source-record parser"
+)
+assert.match(
+  previousSourceRecordParser[1],
+  /current_record_re='\^\(\[0-9a-f\]\{40\}\) \(\[0-9a-f\]\{64\}\)\$'[\s\S]*legacy_ego_record_re='\^\(\[0-9a-f\]\{40\}\) \(\[0-9a-f\]\{40\}\) \(\[0-9a-f\]\{40\}\) \(\[0-9a-f\]\{64\}\)\$'/
+)
+const runPreviousSourceRecordParser = (
+  target: "superego" | "ego",
+  sourceRecord: string,
+  sourceRecordSize = Buffer.byteLength(sourceRecord, "utf8") + 1
+) =>
+  execFileSync(
+    "bash",
+    [
+      "-c",
+      `set -Eeuo pipefail
+${previousSourceRecordParser[0]}
+parse_previous_source_record "$1" "$2" "$3"
+printf '%s|%s|%s|%s\\n' \
+  "\${recorded_previous_commit}" \
+  "\${recorded_previous_sha}" \
+  "\${recorded_previous_tree}" \
+  "\${recorded_previous_validated_superego_commit}"
+`,
+      "source-record-parser",
+      sourceRecord,
+      target,
+      String(sourceRecordSize)
+    ],
+    { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }
+  ).trim()
+
+const currentSourceCommit = "e".repeat(40)
+const currentSourceSha = "f".repeat(64)
+assert.equal(
+  runPreviousSourceRecordParser(
+    "superego",
+    `${currentSourceCommit} ${currentSourceSha}`
+  ),
+  `${currentSourceCommit}|${currentSourceSha}||`
+)
+assert.equal(
+  runPreviousSourceRecordParser(
+    "ego",
+    `${currentSourceCommit} ${currentSourceSha}`
+  ),
+  `${currentSourceCommit}|${currentSourceSha}||`
+)
+const legacyEgoCommit = "a".repeat(40)
+const legacyEgoTree = "b".repeat(40)
+const legacyValidatedSuperego = "c".repeat(40)
+const legacyEgoArchive = "d".repeat(64)
+const legacyEgoRecord = [
+  legacyEgoCommit,
+  legacyEgoTree,
+  legacyValidatedSuperego,
+  legacyEgoArchive
+].join(" ")
+assert.equal(
+  runPreviousSourceRecordParser("ego", legacyEgoRecord),
+  `${legacyEgoCommit}|${legacyEgoArchive}|${legacyEgoTree}|${legacyValidatedSuperego}`
+)
+for (const [target, sourceRecord] of [
+  ["superego", legacyEgoRecord],
+  ["ego", ""],
+  ["ego", legacyEgoCommit],
+  ["ego", `${legacyEgoRecord} extra`],
+  ["ego", `${legacyEgoCommit} ${legacyEgoTree} ${currentSourceSha}`],
+  [
+    "ego",
+    `${legacyEgoCommit}  ${legacyEgoTree} ${legacyValidatedSuperego} ${legacyEgoArchive}`
+  ],
+  ["ego", `${currentSourceCommit}\n${currentSourceSha}`],
+  ["ego", `${currentSourceCommit}  ${currentSourceSha}`],
+  ["ego", `${currentSourceCommit}\t${currentSourceSha}`],
+  ["ego", ` ${currentSourceCommit} ${currentSourceSha}`],
+  ["ego", `${currentSourceCommit} ${currentSourceSha} `],
+  ["ego", `${currentSourceCommit.toUpperCase()} ${currentSourceSha}`],
+  ["ego", `${currentSourceCommit} ${currentSourceSha.toUpperCase()}`],
+  ["ego", `${"g".repeat(40)} ${currentSourceSha}`],
+  ["ego", `${currentSourceCommit} ${"g".repeat(64)}`],
+  ["ego", `${"e".repeat(39)} ${currentSourceSha}`],
+  ["ego", `${"e".repeat(41)} ${currentSourceSha}`],
+  ["ego", `${currentSourceCommit} ${"f".repeat(63)}`],
+  ["ego", `${currentSourceCommit} ${"f".repeat(65)}`],
+  ["ego", `${currentSourceCommit} ${currentSourceSha}\r`]
+] as const) {
+  assert.throws(() => runPreviousSourceRecordParser(target, sourceRecord))
+}
+const legacyEgoFields = [
+  legacyEgoCommit,
+  legacyEgoTree,
+  legacyValidatedSuperego,
+  legacyEgoArchive
+]
+for (const fieldIndex of legacyEgoFields.keys()) {
+  for (const replacement of [
+    legacyEgoFields[fieldIndex].toUpperCase(),
+    `g${legacyEgoFields[fieldIndex].slice(1)}`,
+    legacyEgoFields[fieldIndex].slice(1),
+    `${legacyEgoFields[fieldIndex]}a`
+  ]) {
+    const malformedFields = [...legacyEgoFields]
+    malformedFields[fieldIndex] = replacement
+    assert.throws(() =>
+      runPreviousSourceRecordParser("ego", malformedFields.join(" "))
+    )
+  }
+}
+for (const sourceRecordSize of [105, 107]) {
+  assert.throws(() =>
+    runPreviousSourceRecordParser(
+      "ego",
+      `${currentSourceCommit} ${currentSourceSha}`,
+      sourceRecordSize
+    )
+  )
+}
+for (const sourceRecordSize of [187, 189]) {
+  assert.throws(() =>
+    runPreviousSourceRecordParser("ego", legacyEgoRecord, sourceRecordSize)
+  )
+}
+
+const currentPointerIndex = repeatableReleaseRemote.indexOf(
+  'previous=$(readlink -e "${app_root}/current")'
+)
+const canonicalReleaseNameIndex = repeatableReleaseRemote.indexOf(
+  "[[ ${previous_name} =~ ^([0-9a-f]{40})-([A-Za-z0-9]{8})$ ]]"
+)
+const sourceRecordMetadataIndex = repeatableReleaseRemote.indexOf(
+  `$(stat -c '%U' "\${previous_source_record}") == root`
+)
+const sourceRecordWritableIndex = repeatableReleaseRemote.indexOf(
+  `find "\${previous_source_record}" -maxdepth 0 -perm /022 -print -quit`
+)
+const sourceRecordLineCountIndex = repeatableReleaseRemote.indexOf(
+  `$(awk 'END { print NR }' "\${previous_source_record}") == 1`
+)
+const sourceRecordParserIndex = repeatableReleaseRemote.indexOf(
+  `parse_previous_source_record \\
+  "\${source_record}" \\
+  "\${target}" \\
+  "\${source_record_size}"`
+)
+const previousManifestBindingIndex = repeatableReleaseRemote.indexOf(
+  '[[ ${previous_commit} == "${manifest[previous_commit]}" ]]'
+)
+assert(
+  currentPointerIndex >= 0 &&
+    currentPointerIndex < canonicalReleaseNameIndex &&
+    canonicalReleaseNameIndex < sourceRecordMetadataIndex &&
+    sourceRecordMetadataIndex < sourceRecordWritableIndex &&
+    sourceRecordWritableIndex < sourceRecordLineCountIndex &&
+    sourceRecordLineCountIndex < sourceRecordParserIndex &&
+    sourceRecordParserIndex < previousManifestBindingIndex,
+  "Previous releases must have canonical names and exact trusted records before manifest binding"
+)
+assert.match(
+  repeatableReleaseRemote,
+  /printf '%s %s\\n' \\\n  "\$\{manifest\[commit\]\}" \\\n  "\$\{manifest\[archive_sha256\]\}" \\\n  >"\$\{release\}\/\.matsci-release-source"/
+)
+const resetSuperegoRemote = read("deploy/lib/reset-superego-remote.sh")
+assert.match(
+  resetSuperegoRemote,
+  /chown root:matsci-sam "\$\{release\}\/\.matsci-release-source"\nchmod 0640 "\$\{release\}\/\.matsci-release-source"/
+)
+const historicalEgoReleaseRemote = read(
+  "deploy/lib/deploy-ego-precutover-remote.sh"
+)
+assert.match(
+  historicalEgoReleaseRemote,
+  /printf '%s %s %s %s\\n' \\\n  "\$\{manifest\[commit\]\}" \\\n  "\$\{manifest\[tree\]\}" \\\n  "\$\{manifest\[validated_superego_commit\]\}" \\\n  "\$\{manifest\[archive_sha256\]\}" \\\n  >"\$\{release\}\/\.matsci-release-source"/
+)
+assert.doesNotMatch(
+  repeatableReleaseRemote.slice(
+    sourceRecordMetadataIndex,
+    sourceRecordLineCountIndex
+  ),
+  /%G|%a|root:root:444/
+)
 const reviewedReleaseLauncher = read(
   "deploy/lib/launch-reviewed-release-remote.sh"
 )


### PR DESCRIPTION
## What changed

- Accept the exact historical four-field `.matsci-release-source` format only when releasing to Ego.
- Keep the current two-field format for both environments and for every newly written release record.
- Require canonical release naming, a root-owned non-writable one-line record, exact byte length and lowercase hexadecimal grammar, and the existing commit-to-directory and manifest bindings.
- Add focused contract coverage for both producers, both targets, malformed fields, whitespace, line endings, and byte lengths.

## Why

Ego's first release was created by the reviewed pre-cutover helper, which recorded `commit tree validated_superego_commit archive_sha256`. The routine release helper expected only `commit archive_sha256`, so the first routine Ego release failed closed with `The current release source record is malformed.`

The failed attempt stopped before candidate build, service shutdown, migrations, or database changes. This compatibility reader avoids editing the frozen Ego release and does not invoke or alter the one-time seed path. A successful routine release converges Ego to the current two-field format.

## Compatibility

The trust check accepts both current known metadata forms:

- routine frozen release: root-owned `0444`
- supported Superego reset release: root-owned `0640`

Legacy four-field parsing remains Ego-only and cannot authorize a candidate; the exact reviewed commit must still be live on Superego before Ego.

## Validation

- `pnpm test:deployment`
- `pnpm lint` (two pre-existing React Compiler warnings, no errors)
- `pnpm check-types`
- `pnpm db:check`
- `pnpm test:auth`
- `pnpm test:identifiers`
- `pnpm test:interface`
- `pnpm test:ollama-context`
- full deployment shell `bash -n` set
- `git diff --check`
- two independent no-blocker reviews
