### PR TITLE
Fix OAuth navigation and release checks

### DIFF
--- a/app/api/login/route.ts
+++ b/app/api/login/route.ts
@@ -1,22 +1,5 @@
-import { isDevAuthEnabled } from "@/lib/dev-auth"
-import { isEmailAuthEnabled } from "@/lib/email-auth"
-import { isOrcidAuthEnabled } from "@/lib/apis/orcid"
-
-export const GET = async () => {
-  if (isEmailAuthEnabled() || isOrcidAuthEnabled())
-    return new Response(null, {
-      status: 307,
-      headers: { Location: "/login" }
-    })
-
-  if (isDevAuthEnabled())
-    return new Response(null, {
-      status: 307,
-      headers: { Location: "/dev-login" }
-    })
-
-  return new Response(null, {
+export const GET = () =>
+  new Response(null, {
     status: 307,
-    headers: { Location: "/api/auth/google" }
+    headers: { Location: "/login" }
   })
-}

--- a/app/definition-starter.tsx
+++ b/app/definition-starter.tsx
@@ -65,7 +65,7 @@ export function DefinitionStarter({
       <div className={styles.contributionActions}>
         {signedIn ? null : (
           <Button asChild>
-            <Link href="/api/login">
+            <Link href="/login">
               <FilePlus2Icon aria-hidden />
               Sign in to contribute
             </Link>

--- a/app/discussion/comment-box.tsx
+++ b/app/discussion/comment-box.tsx
@@ -51,7 +51,7 @@ export const DiscussionCommentBox = ({
     toast("You must be logged in to take part!", {
       action: (
         <Button asChild>
-          <Link href="/api/login" className="ml-auto">
+          <Link href="/login" className="ml-auto">
             Login
           </Link>
         </Button>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next"
 import Image from "next/image"
 import Link from "next/link"
-import { redirect } from "next/navigation"
 import { MailIcon } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import {
@@ -24,9 +23,6 @@ export default function LoginPage() {
   const devEnabled = isDevAuthEnabled()
   const emailEnabled = isEmailAuthEnabled()
   const orcidEnabled = isOrcidAuthEnabled()
-  if (!devEnabled && !emailEnabled && !orcidEnabled)
-    redirect("/api/auth/google")
-  if (devEnabled && !emailEnabled && !orcidEnabled) redirect("/dev-login")
 
   return (
     <main className="px-4 py-12">
@@ -42,11 +38,11 @@ export default function LoginPage() {
         </CardHeader>
         <CardContent className="space-y-5">
           <Button asChild variant="outline" className="w-full">
-            <Link href="/api/auth/google">Continue with Google</Link>
+            <a href="/api/auth/google">Continue with Google</a>
           </Button>
           {orcidEnabled ? (
             <Button asChild variant="outline" className="w-full">
-              <Link href="/api/auth/orcid?intent=login">
+              <a href="/api/auth/orcid?intent=login">
                 <Image
                   src="/orcid-id.svg"
                   alt=""
@@ -55,7 +51,7 @@ export default function LoginPage() {
                   aria-hidden
                 />
                 Continue with ORCID
-              </Link>
+              </a>
             </Button>
           ) : null}
           {emailEnabled ? (

--- a/app/profile/edit/page.tsx
+++ b/app/profile/edit/page.tsx
@@ -20,7 +20,7 @@ export const metadata: Metadata = { title: `Edit Profile | ${SITE_NAME}` }
 
 export default async function EditProfilePage() {
   const { user } = await auth()
-  if (!user) redirect("/api/login")
+  if (!user) redirect("/login")
 
   return (
     <main className="px-4 py-8">
@@ -79,7 +79,7 @@ export default async function EditProfilePage() {
                 </div>
               ) : (
                 <Button asChild variant="outline">
-                  <Link href="/api/auth/orcid?intent=connect">
+                  <a href="/api/auth/orcid?intent=connect">
                     <Image
                       src="/orcid-id.svg"
                       alt=""
@@ -88,7 +88,7 @@ export default async function EditProfilePage() {
                       aria-hidden
                     />
                     Connect your ORCID iD
-                  </Link>
+                  </a>
                 </Button>
               )}
             </CardContent>

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -28,7 +28,7 @@ export const metadata: Metadata = { title: `Profile | ${SITE_NAME}` }
 
 export default async function ProfilePage() {
   const { user } = await auth()
-  if (!user) redirect("/api/login")
+  if (!user) redirect("/login")
 
   const authoredTerms = await db
     .select({

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next"
-import Link from "next/link"
 import { notFound } from "next/navigation"
 import { MailIcon } from "lucide-react"
 import { Button } from "@/components/ui/button"
@@ -72,9 +71,9 @@ export default async function RegisterPage({
           </form>
           <p className="text-center text-sm text-muted-foreground">
             Prefer your existing identity?{" "}
-            <Link href="/api/auth/google" className="text-primary underline">
+            <a href="/api/auth/google" className="text-primary underline">
               Continue with Google
-            </Link>
+            </a>
           </p>
         </CardContent>
       </Card>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -122,7 +122,7 @@ const AuthSection = ({
 
   return (
     <Button asChild variant="outline">
-      <Link href="/api/login">Login</Link>
+      <Link href="/login">Login</Link>
     </Button>
   )
 }

--- a/components/term/comment-box.tsx
+++ b/components/term/comment-box.tsx
@@ -62,7 +62,7 @@ export function TermCommentBox({
       toast("You must be logged in to comment!", {
         action: (
           <Button asChild>
-            <Link href="/api/login" className="ml-auto">
+            <Link href="/login" className="ml-auto">
               Login
             </Link>
           </Button>

--- a/components/term/votes.tsx
+++ b/components/term/votes.tsx
@@ -55,7 +55,7 @@ export const TermVotes = ({
         toast("You must be logged in to vote on a definition!", {
           action: (
             <Button asChild>
-              <Link href="/api/login" className="ml-auto">
+              <Link href="/login" className="ml-auto">
                 Login
               </Link>
             </Button>

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -32,6 +32,12 @@ The protected environment on both hosts must set
 `NEXT_PUBLIC_SITE_NAME=MatSci-SAM`; the release refuses a stale display name
 before building.
 
+After a Superego release, exercise the changed behavior before running the Ego
+command. Authentication changes require a real browser sign-in from
+`https://superego.cci.drexel.edu/login`; automated checks prove the internal
+login and provider redirect contract but cannot prove provider credentials or
+identity continuity. Repeat the real sign-in after the Ego release.
+
 Do not run the one-time Ego seed, first-release, or cutover wrappers again.
 `--check-only` remains available for diagnostics but is not a required extra
 step before either command.

--- a/deploy/lib/deploy-superego-in-place-remote.sh
+++ b/deploy/lib/deploy-superego-in-place-remote.sh
@@ -701,7 +701,8 @@ verify_loopback_contract() {
     fail "PostgreSQL unexpectedly has a TCP listener on Ego."
   fi
 
-  local local_paths=(/ /api/health /search /terms /docs /about /metadata/matcore)
+  local local_paths=(/ /api/health /login /search /terms /docs /about /metadata/matcore)
+  local login_headers
   local local_redirect_headers
   local path
   local code
@@ -737,11 +738,28 @@ verify_loopback_contract() {
     [[ ${code} == 200 ]] ||
       fail "Unexpected local status for ${path}: ${code}"
   done
+
+  login_headers=$(
+    curl \
+      --connect-timeout 3 \
+      --max-time 10 \
+      --silent \
+      --show-error \
+      --output /dev/null \
+      --dump-header - \
+      http://127.0.0.1:3000/api/login
+  )
+  verify_redirect_headers \
+    "${login_headers}" \
+    307 \
+    /login \
+    "The local login compatibility entry"
 }
 
 verify_public_contract() {
   local host=${public_host}
-  local public_paths=(/ /api/health /search /terms /docs /about /metadata/matcore)
+  local public_paths=(/ /api/health /login /search /terms /docs /about /metadata/matcore)
+  local login_headers
   local public_redirect_headers
   local google_headers
   local path
@@ -781,6 +799,23 @@ verify_public_contract() {
     [[ ${code} == 200 ]] ||
       fail "Unexpected public status for ${path}: ${code}"
   done
+
+  login_headers=$(
+    curl \
+      --resolve "${host}:443:127.0.0.1" \
+      --connect-timeout 3 \
+      --max-time 10 \
+      --silent \
+      --show-error \
+      --output /dev/null \
+      --dump-header - \
+      "https://${host}/api/login"
+  )
+  verify_redirect_headers \
+    "${login_headers}" \
+    307 \
+    /login \
+    "The public login compatibility entry"
 
   google_headers=$(
     curl \

--- a/deploy/release.sh
+++ b/deploy/release.sh
@@ -407,3 +407,11 @@ if [[ ${operation} == resume-public-verification ]]; then
 else
   echo "${environment_name} in-place release and verification completed."
 fi
+if [[ ${target} == superego ]]; then
+  printf 'Next: exercise the changed behavior at %s, including a real sign-in when authentication changed.\n' \
+    'https://superego.cci.drexel.edu/login'
+  echo "After it passes, release this exact commit with: ./deploy/release.sh ego"
+else
+  printf 'Next: verify the public behavior at %s, including a real sign-in when authentication changed.\n' \
+    'https://ego.cci.drexel.edu/login'
+fi

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -5,7 +5,7 @@ import { eq } from "drizzle-orm"
 
 export const auth = async () => {
   const sesh = await getSession()
-  if (!sesh.id) redirect("/api/login")
+  if (!sesh.id) redirect("/login")
 
   const user = await db.query.usersTable.findFirst({
     where: eq(usersTable.id, sesh.id)
@@ -14,7 +14,7 @@ export const auth = async () => {
   if (!user) {
     sesh.destroy()
     await sesh.save()
-    redirect("/api/login")
+    redirect("/login")
   }
 
   return { sesh, user }

--- a/scripts/test-auth-plumbing.ts
+++ b/scripts/test-auth-plumbing.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict"
+import { readdirSync, readFileSync } from "node:fs"
+import { relative, resolve } from "node:path"
+import { GET as getLogin } from "../app/api/login/route"
 import {
   createOneTimeToken,
   hashOneTimeToken,
@@ -11,6 +14,35 @@ import {
 } from "../lib/input-limits"
 import { isValidOrcidId, normalizeOrcidId } from "../lib/orcid"
 import { DefineTermSchema } from "../lib/schemas/terms"
+
+const loginResponse = getLogin()
+assert.equal(loginResponse.status, 307)
+assert.equal(loginResponse.headers.get("location"), "/login")
+
+const sourceFiles = (directory: string): string[] =>
+  readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = resolve(directory, entry.name)
+    if (entry.isDirectory()) return sourceFiles(path)
+    return entry.isFile() && /\.(?:jsx?|tsx?)$/.test(entry.name) ? [path] : []
+  })
+
+for (const sourcePath of [
+  ...sourceFiles(resolve("app")),
+  ...sourceFiles(resolve("components"))
+]) {
+  const source = readFileSync(sourcePath, "utf8")
+  const displayPath = relative(process.cwd(), sourcePath)
+  assert.doesNotMatch(
+    source,
+    /<Link\b[^>]*\bhref\s*=\s*(?:\{\s*)?["'`]\/api\//,
+    `${displayPath}: Next Link must not client-navigate to a Route Handler`
+  )
+  assert.doesNotMatch(
+    source,
+    /\brouter\.(?:push|replace)\(\s*["'`]\/api\//,
+    `${displayPath}: the client router must not navigate to a Route Handler`
+  )
+}
 
 assert.equal(
   normalizeOrcidId("https://orcid.org/0000-0002-1825-0097"),

--- a/scripts/test-deployment-contract.ts
+++ b/scripts/test-deployment-contract.ts
@@ -578,6 +578,14 @@ assert.match(
 )
 assert.match(
   repeatableRelease,
+  /superego\.cci\.drexel\.edu\/login[\s\S]*release this exact commit with: \.\/deploy\/release\.sh ego/
+)
+assert.match(
+  repeatableRelease,
+  /ego\.cci\.drexel\.edu\/login/
+)
+assert.match(
+  repeatableRelease,
   /--resume-public-verification[\s\S]*resume-public-verification/
 )
 assert.match(
@@ -1181,6 +1189,52 @@ assert(
 assert.match(
   releaseRollbackFunction[1],
   /database_mutation_started} == true[\s\S]*Restoring the prior release and database state[\s\S]*live_vector_normalized} == true[\s\S]*application data was unchanged[\s\S]*the database was unchanged/
+)
+
+const loopbackContractFunction = repeatableReleaseRemote.match(
+  /^verify_loopback_contract\(\) \{\n([\s\S]*?)^\}$/m
+)
+assert(
+  loopbackContractFunction,
+  "Could not locate the shared loopback verification contract"
+)
+assert.match(
+  loopbackContractFunction[1],
+  /local_paths=\(\/ \/api\/health \/login /
+)
+assert.match(
+  loopbackContractFunction[1],
+  /http:\/\/127\.0\.0\.1:3000\/api\/login[\s\S]*verify_redirect_headers[\s\S]*307[\s\S]*\/login[\s\S]*local login compatibility entry/
+)
+
+const publicContractFunction = repeatableReleaseRemote.match(
+  /^verify_public_contract\(\) \{\n([\s\S]*?)^\}$/m
+)
+assert(
+  publicContractFunction,
+  "Could not locate the shared public verification contract"
+)
+assert.match(
+  publicContractFunction[1],
+  /public_paths=\(\/ \/api\/health \/login /
+)
+const publicLoginCompatibilityIndex = publicContractFunction[1].indexOf(
+  '"https://${host}/api/login"'
+)
+const publicGoogleEntryIndex = publicContractFunction[1].indexOf(
+  '"https://${host}/api/auth/google"'
+)
+assert(
+  publicLoginCompatibilityIndex >= 0 &&
+    publicLoginCompatibilityIndex < publicGoogleEntryIndex &&
+    publicContractFunction[1]
+      .slice(publicLoginCompatibilityIndex, publicGoogleEntryIndex)
+      .includes("The public login compatibility entry"),
+  "Public verification must check the internal login page before Google OAuth"
+)
+assert.match(
+  publicContractFunction[1],
+  /Google entry did not return HTTP 307[\s\S]*accounts\.google\.com/
 )
 
 const publicHttpsWaitFunction = repeatableReleaseRemote.match(


### PR DESCRIPTION
## Summary

- route all generic sign-in entry points through `/login`
- use full-document navigation for Google and ORCID authorization endpoints
- add CI and deployment checks for the login compatibility contract
- improve the Superego-to-Ego authentication verification handoff

## Root cause

Next.js `<Link>` client-routed `/api/login`. On Ego, that route redirected to Google, so the RSC fetch followed the cross-origin OAuth redirect and failed CORS. The Superego development-login redirect remained same-origin, which hid the defect there.

## User impact

Ego login now shows the shared sign-in page and starts Google OAuth as a top-level document navigation. Superego retains both Google and development sign-in options.

## Validation

- `pnpm lint` (two existing React Compiler compatibility warnings only)
- `pnpm check-types`
- `pnpm test:auth`
- `pnpm test:identifiers`
- `pnpm test:interface`
- `pnpm test:ollama-context`
- `pnpm test:deployment`
- `pnpm db:check`
- `pnpm build`
- local production smoke: `/login` returned 200 and `/api/login` returned 307 to `/login`