### PR TITLE
Enable explicit email account registration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,10 +16,11 @@ ORCID_CALLBACK_URL="http://localhost:3000/api/auth/orcid/callback"
 ORCID_SCOPES="openid"
 # Generate with: openssl rand -base64 32
 AUTH_TOKEN_ENCRYPTION_KEY=""
-# Passwordless account creation and sign-in. Keep false until the sender and
-# one-time-link workflow have passed an end-to-end delivery test.
+# Passwordless sign-in and explicit account creation. Keep both false until the
+# sender and one-time-link workflow have passed an end-to-end delivery test.
 # The application limits each address to one request per minute.
 EMAIL_AUTH_ENABLED=false
+EMAIL_AUTH_ACCOUNT_CREATION_ENABLED=false
 EMAIL_AUTH_PROVIDER="gmail-api"
 EMAIL_AUTH_FROM=""
 # Preferred pilot provider. Authorize only the gmail.send scope.

--- a/app/api/auth/email/start/route.ts
+++ b/app/api/auth/email/start/route.ts
@@ -1,12 +1,14 @@
-import { db, emailAuthTokensTable } from "@yamz/db"
+import { db, emailAuthTokensTable, usersTable } from "@yamz/db"
 import { and, eq, gt, isNull, lt, sql } from "drizzle-orm"
 import { after, NextRequest, NextResponse } from "next/server"
 import {
   createEmailAuthToken,
   EmailAddressSchema,
+  EmailAuthIntentSchema,
   emailAuthTokenExpiry,
   getAuthSiteUrl,
   hashEmailAuthToken,
+  isEmailAccountCreationEnabled,
   isEmailAuthEnabled
 } from "@/lib/email-auth"
 import { sendEmailSignInLink } from "@/lib/email"
@@ -23,9 +25,14 @@ export const POST = async (request: NextRequest) => {
 
   const form = await request.formData()
   const parsed = EmailAddressSchema.safeParse(form.get("email"))
-  if (!parsed.success) return genericRedirect()
+  const parsedIntent = EmailAuthIntentSchema.safeParse(form.get("intent"))
+  if (!parsed.success || !parsedIntent.success) return genericRedirect()
 
   const email = parsed.data
+  const allowAccountCreation = parsedIntent.data === "create"
+  if (allowAccountCreation && !isEmailAccountCreationEnabled())
+    return genericRedirect()
+
   const now = new Date().toISOString()
   await db
     .delete(emailAuthTokensTable)
@@ -41,6 +48,20 @@ export const POST = async (request: NextRequest) => {
     await tx.execute(
       sql`select pg_advisory_xact_lock(hashtextextended(${email}, 0))`
     )
+
+    if (!allowAccountCreation) {
+      const [existingUser] = await tx
+        .select({ id: usersTable.id })
+        .from(usersTable)
+        .where(
+          and(
+            sql`lower(${usersTable.email}) = ${email}`,
+            eq(usersTable.isAi, false)
+          )
+        )
+        .limit(1)
+      if (!existingUser) return false
+    }
 
     const recentThreshold = new Date(Date.now() - 60 * 1000).toISOString()
     const [recent] = await tx
@@ -67,6 +88,7 @@ export const POST = async (request: NextRequest) => {
     await tx.insert(emailAuthTokensTable).values({
       tokenHash,
       email,
+      allowAccountCreation,
       expiresAt: emailAuthTokenExpiry()
     })
     return true

--- a/app/api/auth/email/verify/route.ts
+++ b/app/api/auth/email/verify/route.ts
@@ -38,7 +38,10 @@ export const POST = async (request: Request) => {
           gt(emailAuthTokensTable.expiresAt, now)
         )
       )
-      .returning({ email: emailAuthTokensTable.email })
+      .returning({
+        email: emailAuthTokensTable.email,
+        allowAccountCreation: emailAuthTokensTable.allowAccountCreation
+      })
     if (!claimed) return null
 
     const [existingUser] = await tx
@@ -63,7 +66,7 @@ export const POST = async (request: Request) => {
         .where(eq(usersTable.id, user.id))
         .returning()
       user = updatedUser
-    } else {
+    } else if (claimed.allowAccountCreation) {
       const [insertedUser] = await tx
         .insert(usersTable)
         .values({
@@ -90,7 +93,7 @@ export const POST = async (request: Request) => {
       }
     }
 
-    if (!user) throw new Error("Verified account could not be created")
+    if (!user) return null
 
     await tx
       .update(emailAuthTokensTable)

--- a/app/api/auth/orcid/callback/route.ts
+++ b/app/api/auth/orcid/callback/route.ts
@@ -6,7 +6,7 @@ import {
   connectOrcidAccount,
   findOrcidAccountUserId
 } from "@/lib/orcid-account"
-import { isEmailAuthEnabled } from "@/lib/email-auth"
+import { isEmailAccountCreationEnabled } from "@/lib/email-auth"
 import { getSession } from "@/lib/session"
 import { revalidatePath } from "next/cache"
 import { NextRequest, NextResponse } from "next/server"
@@ -65,7 +65,7 @@ export const GET = async (request: NextRequest) => {
 
   const userId = await findOrcidAccountUserId(tokens.orcidId)
   if (!userId) {
-    if (isEmailAuthEnabled())
+    if (isEmailAccountCreationEnabled())
       return redirectTo(request, "/register?source=orcid")
     return new Response(
       "This ORCID iD is not connected to an account. Sign in with Google first, then connect ORCID from your profile.",

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -13,7 +13,10 @@ import {
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { isDevAuthEnabled } from "@/lib/dev-auth"
-import { isEmailAuthEnabled } from "@/lib/email-auth"
+import {
+  isEmailAccountCreationEnabled,
+  isEmailAuthEnabled
+} from "@/lib/email-auth"
 import { isOrcidAuthEnabled } from "@/lib/apis/orcid"
 import { SITE_NAME } from "@/lib/site"
 
@@ -22,6 +25,7 @@ export const metadata: Metadata = { title: `Sign in | ${SITE_NAME}` }
 export default function LoginPage() {
   const devEnabled = isDevAuthEnabled()
   const emailEnabled = isEmailAuthEnabled()
+  const emailAccountCreationEnabled = isEmailAccountCreationEnabled()
   const orcidEnabled = isOrcidAuthEnabled()
 
   return (
@@ -32,8 +36,7 @@ export default function LoginPage() {
             Sign in to {SITE_NAME}
           </CardTitle>
           <CardDescription>
-            Continue with an existing identity or verify your email to create an
-            account.
+            Continue with an identity already connected to your account.
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-5">
@@ -66,6 +69,7 @@ export default function LoginPage() {
                 method="post"
                 className="space-y-4"
               >
+                <input type="hidden" name="intent" value="sign-in" />
                 <div className="space-y-2">
                   <Label htmlFor="login-email">Email address</Label>
                   <div className="relative">
@@ -89,10 +93,14 @@ export default function LoginPage() {
                   Email me a sign-in link
                 </Button>
               </form>
-              <p className="text-center text-sm text-muted-foreground">
-                New here? Verifying your email creates your account
-                automatically.
-              </p>
+              {emailAccountCreationEnabled ? (
+                <p className="text-center text-sm text-muted-foreground">
+                  New here?{" "}
+                  <Link href="/register" className="text-primary underline">
+                    Create an account by email
+                  </Link>
+                </p>
+              ) : null}
             </>
           ) : null}
           {devEnabled ? (

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import { isEmailAuthEnabled } from "@/lib/email-auth"
+import { isEmailAccountCreationEnabled } from "@/lib/email-auth"
 import { SITE_NAME } from "@/lib/site"
 
 export const metadata: Metadata = {
@@ -23,7 +23,7 @@ export default async function RegisterPage({
 }: {
   searchParams: Promise<{ source?: string }>
 }) {
-  if (!isEmailAuthEnabled()) notFound()
+  if (!isEmailAccountCreationEnabled()) notFound()
   const { source } = await searchParams
 
   return (
@@ -38,7 +38,8 @@ export default async function RegisterPage({
           </CardTitle>
           <CardDescription className="leading-6">
             Enter your email address. We will send a short-lived, one-time link
-            that confirms the address and signs you in. No password is required.
+            that confirms the address and creates your account. No password is
+            required.
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-5">
@@ -48,11 +49,17 @@ export default async function RegisterPage({
               email first, then connect ORCID from your profile.
             </p>
           ) : null}
+          <p className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-sm leading-5">
+            Already have contributions here? Continue with the same Google
+            account first so your existing work stays attached to your account.
+            Email registration is for new contributors.
+          </p>
           <form
             action="/api/auth/email/start"
             method="post"
             className="space-y-4"
           >
+            <input type="hidden" name="intent" value="create" />
             <div className="space-y-2">
               <Label htmlFor="registration-email">Email address</Label>
               <Input
@@ -66,7 +73,7 @@ export default async function RegisterPage({
               />
             </div>
             <Button type="submit" className="w-full">
-              Email me a sign-in link
+              Create account by email
             </Button>
           </form>
           <p className="text-center text-sm text-muted-foreground">

--- a/app/register/verify/verify-email-link.tsx
+++ b/app/register/verify/verify-email-link.tsx
@@ -91,7 +91,7 @@ export function VerifyEmailLink() {
                 {error}
               </p>
               <Button asChild variant="outline" className="w-full">
-                <Link href="/register">Request another link</Link>
+                <Link href="/login">Request another link</Link>
               </Button>
             </div>
           ) : (

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -70,6 +70,10 @@ step before either command.
 - `release.sh <superego|ego>` is the repeatable release path. It preserves
   each environment's own database and requires an Ego commit to be running on
   Superego first.
+- `configure-email-auth.sh <superego|ego> <stage|enable|disable>` copies the
+  locally authorized Gmail send-only credentials into protected runtime
+  settings without printing them. It requires supervised remote sudo and does
+  not restart or deploy the application.
 - `deploy-superego-from-workstation.sh` publishes reviewed source while
   preserving and migrating the Superego-authoritative database. It remains as
   a compatible direct entry point; routine releases use `release.sh`.

--- a/deploy/app.env.example
+++ b/deploy/app.env.example
@@ -27,6 +27,7 @@ ORCID_SCOPES=openid
 
 # Enable only after an end-to-end sender and one-time-link test.
 EMAIL_AUTH_ENABLED=false
+EMAIL_AUTH_ACCOUNT_CREATION_ENABLED=false
 EMAIL_AUTH_PROVIDER=gmail-api
 EMAIL_AUTH_FROM=
 EMAIL_AUTH_GMAIL_CLIENT_ID=

--- a/deploy/configure-email-auth.sh
+++ b/deploy/configure-email-auth.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+umask 0077
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+repo=$(cd -- "${script_dir}/.." && pwd)
+remote_helper=${script_dir}/lib/configure-email-auth-remote.sh
+client_file=${MATSCI_GMAIL_CLIENT_FILE:-/home/chris/.config/matsci-sam/google-mail-oauth-client.json}
+token_file=${MATSCI_GMAIL_TOKEN_FILE:-/home/chris/.config/matsci-sam/google-mail-token.json}
+target=${1:-}
+action=${2:-}
+check_only=false
+work_dir=
+remote_dir=
+remote_staged=false
+
+usage() {
+  cat <<'USAGE'
+Usage: deploy/configure-email-auth.sh <superego|ego> <stage|enable|disable> [--check-only]
+
+Safely install the existing local Gmail send-only credentials and set the
+passwordless-email feature flags in the selected protected runtime settings.
+
+  stage     Install or refresh credentials with both feature flags false.
+  enable    Install or refresh credentials and enable sign-in and registration.
+  disable   Set both feature flags false without changing sender credentials.
+
+The command does not restart or deploy the application. A reviewed release
+must follow an enable or disable operation before built pages reflect it.
+USAGE
+}
+
+fail() {
+  echo "$*" >&2
+  exit 1
+}
+
+cleanup() {
+  status=$?
+  trap - EXIT HUP INT TERM
+
+  if [[ ${remote_staged} == true && -n ${remote_dir} ]]; then
+    ssh -o BatchMode=yes "${ssh_host}" \
+      "if [[ -d '${remote_dir}' && ! -L '${remote_dir}' ]]; then
+         find '${remote_dir}' -mindepth 1 -delete 2>/dev/null || true
+         rmdir '${remote_dir}' 2>/dev/null || true
+       fi" \
+      >/dev/null 2>&1 || true
+  fi
+
+  if [[ -n ${work_dir} && -d ${work_dir} ]]; then
+    find "${work_dir}" -mindepth 1 -delete
+    rmdir "${work_dir}"
+  fi
+
+  exit "${status}"
+}
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+case ${target} in
+  superego)
+    ssh_host=superego
+    admin_workspace=/home/cr625/superego-admin
+    ;;
+  ego)
+    ssh_host=ego
+    admin_workspace=/home/cr625/ego-admin
+    ;;
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac
+
+case ${action} in
+  stage|enable|disable)
+    ;;
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac
+
+shift 2
+while (($#)); do
+  case $1 in
+    --check-only)
+      check_only=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "Unknown option: $1"
+      ;;
+  esac
+done
+
+for command in awk base64 date find git id install mktemp node rmdir scp \
+  sha256sum ssh stat
+do
+  command -v "${command}" >/dev/null ||
+    fail "Required command is unavailable: ${command}"
+done
+
+[[ -f ${remote_helper} && ! -L ${remote_helper} ]] ||
+  fail "The reviewed remote email-auth helper is unavailable."
+git -C "${repo}" fetch --prune origin dev
+[[ -z $(git -C "${repo}" status --porcelain=v1) ]] ||
+  fail "Run from a clean reviewed checkout."
+candidate=$(git -C "${repo}" rev-parse HEAD)
+[[ ${candidate} == "$(git -C "${repo}" rev-parse refs/remotes/origin/dev)" ]] ||
+  fail "The checkout must equal the reviewed origin/dev commit."
+
+if [[ ${action} != disable ]]; then
+  for protected_file in "${client_file}" "${token_file}"; do
+    [[ -f ${protected_file} && ! -L ${protected_file} ]] ||
+      fail "A protected Gmail sender file is unavailable: ${protected_file}"
+    [[ $(stat -c '%U:%a' "${protected_file}") == "$(id -un):600" ]] ||
+      fail "A protected Gmail sender file must be owned by the current user with mode 0600."
+  done
+fi
+
+work_dir=$(mktemp -d)
+payload=${work_dir}/email-auth-settings.json
+
+node - "${action}" "${client_file}" "${token_file}" "${payload}" <<'NODE'
+const fs = require("node:fs")
+
+const [, , action, clientPath, tokenPath, outputPath] = process.argv
+let settings
+
+if (action === "disable") {
+  settings = {
+    EMAIL_AUTH_ENABLED: "false",
+    EMAIL_AUTH_ACCOUNT_CREATION_ENABLED: "false"
+  }
+} else {
+  const clientDocument = JSON.parse(fs.readFileSync(clientPath, "utf8"))
+  const tokenDocument = JSON.parse(fs.readFileSync(tokenPath, "utf8"))
+  const client = clientDocument.web
+  const callbackUrl = "http://localhost:53682/oauth2callback"
+  const sendScope = "https://www.googleapis.com/auth/gmail.send"
+
+  if (!client?.client_id || !client.client_secret)
+    throw new Error("The Gmail OAuth client file is incomplete")
+  if (!client.redirect_uris?.includes(callbackUrl))
+    throw new Error(`The Gmail OAuth client is missing ${callbackUrl}`)
+  if (!tokenDocument.refresh_token)
+    throw new Error("The Gmail OAuth refresh token is missing")
+  if (tokenDocument.scope !== sendScope)
+    throw new Error("The Gmail OAuth token does not record the send-only scope")
+
+  const enabled = action === "enable" ? "true" : "false"
+  settings = {
+    EMAIL_AUTH_ENABLED: enabled,
+    EMAIL_AUTH_ACCOUNT_CREATION_ENABLED: enabled,
+    EMAIL_AUTH_PROVIDER: "gmail-api",
+    EMAIL_AUTH_FROM: "matsci-sam@systemada.com",
+    EMAIL_AUTH_GMAIL_CLIENT_ID: client.client_id,
+    EMAIL_AUTH_GMAIL_CLIENT_SECRET: client.client_secret,
+    EMAIL_AUTH_GMAIL_REFRESH_TOKEN: tokenDocument.refresh_token,
+    EMAIL_AUTH_TOKEN_TTL_MINUTES: "15"
+  }
+}
+
+fs.writeFileSync(outputPath, `${JSON.stringify(settings)}\n`, {
+  encoding: "utf8",
+  mode: 0o600,
+  flag: "wx"
+})
+NODE
+
+payload_sha=$(sha256sum "${payload}" | awk '{print $1}')
+helper_base64=$(base64 --wrap=0 "${remote_helper}")
+remote_id="email-auth-$(date -u +%Y%m%dT%H%M%SZ)-$$"
+remote_dir="${admin_workspace}/incoming/${remote_id}"
+
+ssh "${ssh_host}" "mkdir --mode=0700 '${remote_dir}'"
+remote_staged=true
+scp "${payload}" "${ssh_host}:${remote_dir}/email-auth-settings.json"
+
+if [[ ${check_only} == true ]]; then
+  remote_check=true
+else
+  remote_check=false
+  [[ -t 0 ]] ||
+    fail "Run interactively so sudo can confirm the protected configuration change."
+fi
+
+ssh -t "${ssh_host}" \
+  "set -o pipefail
+   /usr/bin/printf '%s' '${helper_base64}' |
+   /usr/bin/base64 --decode |
+   /usr/bin/sudo /bin/bash -s -- \
+     '${remote_dir}/email-auth-settings.json' \
+     '${target}' \
+     '${payload_sha}' \
+     '${action}' \
+     '${remote_check}'"
+
+ssh "${ssh_host}" \
+  "if [[ -d '${remote_dir}' && ! -L '${remote_dir}' ]]; then
+     find '${remote_dir}' -mindepth 1 -delete
+     rmdir '${remote_dir}'
+   fi"
+remote_staged=false
+
+if [[ ${check_only} == true ]]; then
+  echo "Email-auth configuration check passed for ${target}."
+else
+  echo "Email-auth configuration ${action} completed for ${target}."
+  echo "No service was restarted. Apply the setting through the reviewed release path."
+fi

--- a/deploy/ego/app.env.example
+++ b/deploy/ego/app.env.example
@@ -29,6 +29,7 @@ ORCID_SCOPES=openid
 
 # Enable only after an end-to-end sender and one-time-link test.
 EMAIL_AUTH_ENABLED=false
+EMAIL_AUTH_ACCOUNT_CREATION_ENABLED=false
 EMAIL_AUTH_PROVIDER=gmail-api
 EMAIL_AUTH_FROM=
 EMAIL_AUTH_GMAIL_CLIENT_ID=

--- a/deploy/lib/configure-email-auth-remote.sh
+++ b/deploy/lib/configure-email-auth-remote.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+umask 0077
+export PATH=/usr/sbin:/usr/bin:/sbin:/bin
+cd /
+
+payload=${1:-}
+target=${2:-}
+expected_payload_sha=${3:-}
+action=${4:-}
+check_only=${5:-}
+config=/etc/matsci-sam/app.env
+admin_root=/var/lib/matsci-sam-admin
+backup_root=${admin_root}/config-backups
+partial=
+payload_identity=
+
+fail() {
+  echo "$*" >&2
+  exit 1
+}
+
+cleanup() {
+  status=$?
+  trap - EXIT HUP INT TERM
+
+  if [[ -n ${partial} && (-e ${partial} || -L ${partial}) ]]; then
+    if [[ ${partial} =~ ^/etc/matsci-sam/[.]app[.]env[.][A-Za-z0-9]{8}$ &&
+      -f ${partial} && ! -L ${partial} ]]
+    then
+      unlink "${partial}" || status=1
+    else
+      echo "Refusing to remove an unsafe protected-settings partial." >&2
+      status=1
+    fi
+  fi
+
+  if [[ -n ${payload_identity} && -f ${payload} && ! -L ${payload} &&
+    $(stat -c '%d:%i' "${payload}") == "${payload_identity}" ]]
+  then
+    truncate --size=0 "${payload}" || status=1
+    unlink "${payload}" || status=1
+  fi
+
+  exit "${status}"
+}
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+for command in bash date hostname id install mkdir mktemp mv node sha256sum \
+  stat truncate unlink
+do
+  command -v "${command}" >/dev/null ||
+    fail "Required command is unavailable: ${command}"
+done
+
+[[ $# -eq 5 ]] ||
+  fail "The protected email-auth configuration request is malformed."
+[[ $(id -u) -eq 0 ]] ||
+  fail "Run this helper by streaming it to sudo bash."
+
+case ${target} in
+  superego)
+    expected_hostname=cci-superego
+    admin_workspace=/home/cr625/superego-admin
+    ;;
+  ego)
+    expected_hostname=cci-ego
+    admin_workspace=/home/cr625/ego-admin
+    ;;
+  *)
+    fail "Unknown email-auth environment: ${target}"
+    ;;
+esac
+case ${action} in
+  stage|enable|disable)
+    ;;
+  *)
+    fail "Unknown email-auth configuration action: ${action}"
+    ;;
+esac
+[[ ${check_only} == true || ${check_only} == false ]] ||
+  fail "The email-auth check-only value is invalid."
+[[ $(hostname) == "${expected_hostname}" ]] ||
+  fail "This helper runs only on ${expected_hostname}."
+[[ ${expected_payload_sha} =~ ^[0-9a-f]{64}$ ]] ||
+  fail "The expected email-auth payload digest is malformed."
+
+payload_pattern="^${admin_workspace}/incoming/email-auth-[0-9]{8}T[0-9]{6}Z-[0-9]+/email-auth-settings[.]json$"
+[[ ${payload} =~ ${payload_pattern} ]] ||
+  fail "The email-auth payload is outside the reviewed incoming area."
+payload_directory=${payload%/*}
+[[ -d ${payload_directory} && ! -L ${payload_directory} &&
+  $(stat -c '%U:%a' "${payload_directory}") == cr625:700 ]] ||
+  fail "The email-auth payload directory is unsafe."
+[[ -f ${payload} && ! -L ${payload} &&
+  $(stat -c '%U:%a' "${payload}") == cr625:600 ]] ||
+  fail "The email-auth payload is unsafe."
+payload_identity=$(stat -c '%d:%i' "${payload}")
+[[ $(sha256sum "${payload}" | awk '{print $1}') == \
+  "${expected_payload_sha}" ]] ||
+  fail "The email-auth payload digest does not match."
+
+[[ -f ${config} && ! -L ${config} &&
+  $(stat -c '%U:%G:%a' "${config}") == root:matsci-sam:640 ]] ||
+  fail "The protected application environment is unsafe."
+[[ -d ${admin_root} && ! -L ${admin_root} &&
+  $(stat -c '%U:%G:%a' "${admin_root}") == root:root:700 ]] ||
+  fail "The protected administration directory is unsafe."
+
+partial=$(mktemp /etc/matsci-sam/.app.env.XXXXXXXX)
+
+node - "${config}" "${payload}" "${partial}" "${action}" "${check_only}" <<'NODE'
+const fs = require("node:fs")
+
+const [, , configPath, payloadPath, outputPath, action, checkOnly] = process.argv
+const payload = JSON.parse(fs.readFileSync(payloadPath, "utf8"))
+const original = fs.readFileSync(configPath, "utf8")
+const allowedKeys = new Set([
+  "EMAIL_AUTH_ENABLED",
+  "EMAIL_AUTH_ACCOUNT_CREATION_ENABLED",
+  "EMAIL_AUTH_PROVIDER",
+  "EMAIL_AUTH_FROM",
+  "EMAIL_AUTH_GMAIL_CLIENT_ID",
+  "EMAIL_AUTH_GMAIL_CLIENT_SECRET",
+  "EMAIL_AUTH_GMAIL_REFRESH_TOKEN",
+  "EMAIL_AUTH_TOKEN_TTL_MINUTES"
+])
+const keys = Object.keys(payload)
+const expectedKeys =
+  action === "disable"
+    ? ["EMAIL_AUTH_ENABLED", "EMAIL_AUTH_ACCOUNT_CREATION_ENABLED"]
+    : [...allowedKeys]
+
+if (
+  keys.length !== expectedKeys.length ||
+  expectedKeys.some((key) => !Object.hasOwn(payload, key)) ||
+  keys.some((key) => !allowedKeys.has(key))
+)
+  throw new Error("The email-auth payload has an unexpected key set")
+
+for (const [key, value] of Object.entries(payload)) {
+  if (typeof value !== "string" || value.includes("\n") || value.includes("\r"))
+    throw new Error(`The email-auth value for ${key} is invalid`)
+}
+if (!/^(?:true|false)$/.test(payload.EMAIL_AUTH_ENABLED))
+  throw new Error("EMAIL_AUTH_ENABLED must be true or false")
+if (!/^(?:true|false)$/.test(payload.EMAIL_AUTH_ACCOUNT_CREATION_ENABLED))
+  throw new Error("EMAIL_AUTH_ACCOUNT_CREATION_ENABLED must be true or false")
+if (
+  payload.EMAIL_AUTH_ACCOUNT_CREATION_ENABLED === "true" &&
+  payload.EMAIL_AUTH_ENABLED !== "true"
+)
+  throw new Error("Account creation requires email authentication")
+
+if (action !== "disable") {
+  if (payload.EMAIL_AUTH_PROVIDER !== "gmail-api")
+    throw new Error("The staged email provider must be gmail-api")
+  if (!/^[A-Za-z0-9.!#$%&*+/=?^_`{|}~-]+@[A-Za-z0-9.-]+$/.test(payload.EMAIL_AUTH_FROM))
+    throw new Error("The staged From address is invalid")
+  for (const key of [
+    "EMAIL_AUTH_GMAIL_CLIENT_ID",
+    "EMAIL_AUTH_GMAIL_CLIENT_SECRET",
+    "EMAIL_AUTH_GMAIL_REFRESH_TOKEN"
+  ]) {
+    if (!/^[A-Za-z0-9._/-]+$/.test(payload[key]))
+      throw new Error(`The staged credential format for ${key} is invalid`)
+  }
+  if (!/^(?:[5-9]|[1-5][0-9]|60)$/.test(payload.EMAIL_AUTH_TOKEN_TTL_MINUTES))
+    throw new Error("The staged token lifetime is invalid")
+}
+
+const lines = original.split(/\r?\n/)
+const counts = new Map()
+for (const line of lines) {
+  const match = line.match(/^([A-Z][A-Z0-9_]*)=/)
+  if (match && allowedKeys.has(match[1]))
+    counts.set(match[1], (counts.get(match[1]) || 0) + 1)
+}
+for (const key of keys) {
+  if ((counts.get(key) || 0) > 1)
+    throw new Error(`The protected environment contains duplicate ${key} entries`)
+}
+
+const replacements = new Map(
+  Object.entries(payload).map(([key, value]) => [key, `${key}='${value}'`])
+)
+const merged = []
+for (const line of lines) {
+  const match = line.match(/^([A-Z][A-Z0-9_]*)=/)
+  const replacement = match ? replacements.get(match[1]) : undefined
+  if (replacement) {
+    merged.push(replacement)
+    replacements.delete(match[1])
+  } else {
+    merged.push(line)
+  }
+}
+if (replacements.size) {
+  if (merged.at(-1) !== "") merged.push("")
+  merged.push("# Passwordless email authentication")
+  merged.push(...replacements.values())
+}
+while (merged.length > 1 && merged.at(-1) === "" && merged.at(-2) === "")
+  merged.pop()
+const rendered = `${merged.join("\n").replace(/\n*$/, "")}\n`
+
+if (checkOnly === "true") {
+  let changes = 0
+  for (const [key, value] of Object.entries(payload)) {
+    const current = lines.find((line) => line.startsWith(`${key}=`))
+    if (current !== `${key}='${value}'`) changes += 1
+    const sensitive = key.includes("SECRET") || key.includes("REFRESH_TOKEN")
+    const state = current ? "set" : "missing"
+    if (sensitive) console.log(`${key}=${state}`)
+    else if (key.endsWith("_ENABLED")) console.log(`${key}=would_be_${value}`)
+    else console.log(`${key}=${state}`)
+  }
+  console.log(`changes_required=${changes}`)
+} else {
+  fs.writeFileSync(outputPath, rendered, { encoding: "utf8", mode: 0o600 })
+}
+NODE
+
+if [[ ${check_only} == true ]]; then
+  unlink "${partial}"
+  partial=
+  echo "Protected email-auth configuration check completed; no values were displayed."
+  exit 0
+fi
+
+bash -n "${partial}" ||
+  fail "The candidate protected environment is not valid shell syntax."
+
+mkdir -p "${backup_root}"
+[[ -d ${backup_root} && ! -L ${backup_root} ]] ||
+  fail "The protected configuration-backup directory is unsafe."
+chown root:root "${backup_root}"
+chmod 0700 "${backup_root}"
+backup=$(mktemp "${backup_root}/app.env.$(date -u +%Y%m%dT%H%M%SZ).XXXXXXXX")
+install -o root -g root -m 0400 "${config}" "${backup}"
+
+chown root:matsci-sam "${partial}"
+chmod 0640 "${partial}"
+mv -f "${partial}" "${config}"
+partial=
+
+[[ -f ${config} && ! -L ${config} &&
+  $(stat -c '%U:%G:%a' "${config}") == root:matsci-sam:640 ]] ||
+  fail "The protected application environment was not installed safely."
+
+echo "Protected email-auth configuration ${action} completed."
+echo "No secret values were displayed and no service was restarted."

--- a/deploy/lib/deploy-superego-in-place-remote.sh
+++ b/deploy/lib/deploy-superego-in-place-remote.sh
@@ -205,6 +205,13 @@ if [[ ${target} == ego ]]; then
     exit 1
   }
 fi
+if [[ ${EMAIL_AUTH_ACCOUNT_CREATION_ENABLED:-false} == true &&
+  ${EMAIL_AUTH_ENABLED:-false} != true ]]
+then
+  echo "EMAIL_AUTH_ENABLED must be true when email account creation is enabled." >&2
+  exit 1
+fi
+
 if [[ ${EMAIL_AUTH_ENABLED:-false} == true ]]; then
   [[ -n ${EMAIL_AUTH_FROM:-} ]] || {
     echo "EMAIL_AUTH_FROM is required when email authentication is enabled." >&2

--- a/deploy/lib/verify-superego-public-content.sh
+++ b/deploy/lib/verify-superego-public-content.sh
@@ -44,10 +44,12 @@ operations_only_paths=(
   README.md
   developing.md
   deploy/README.md
+  deploy/configure-email-auth.sh
   deploy/cutover-ego-public.sh
   deploy/deploy-ego-from-workstation.sh
   deploy/ego/AGENTS.md
   deploy/lib/cutover-ego-public-remote.sh
+  deploy/lib/configure-email-auth-remote.sh
   deploy/lib/deploy-ego-precutover-remote.sh
   deploy/lib/export-superego-for-ego-seed-remote.sh
   deploy/lib/seed-ego-from-superego-remote.sh

--- a/deploy/ops/matsci-sam-ops
+++ b/deploy/ops/matsci-sam-ops
@@ -112,6 +112,7 @@ case $1 in
         expected[++expected_count] = "AUTH_TOKEN_ENCRYPTION_KEY"
         expected[++expected_count] = "ORCID_AUTH_ENABLED"
         expected[++expected_count] = "EMAIL_AUTH_ENABLED"
+        expected[++expected_count] = "EMAIL_AUTH_ACCOUNT_CREATION_ENABLED"
         expected[++expected_count] = "DEV_AUTH_ENABLED"
         expected[++expected_count] = "OLLAMA_HOST"
         expected[++expected_count] = "SYSTEM_PROMPT_KEY"

--- a/drizzle/migrations/0027_hard_killraven.sql
+++ b/drizzle/migrations/0027_hard_killraven.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "emailAuthTokens" ADD COLUMN "allowAccountCreation" boolean DEFAULT false NOT NULL;

--- a/drizzle/migrations/meta/0027_snapshot.json
+++ b/drizzle/migrations/meta/0027_snapshot.json
@@ -1,0 +1,2366 @@
+{
+  "id": "202ea5a5-1a40-4c41-83f6-47f32b2137f3",
+  "prevId": "d957e699-eb77-49d3-abf9-c5de5f57bb5a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.chats": {
+      "name": "chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "chats_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "termId": {
+          "name": "termId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "chat_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "promptKey": {
+          "name": "promptKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promptHash": {
+          "name": "promptHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promptText": {
+          "name": "promptText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chats_termId_terms_id_fk": {
+          "name": "chats_termId_terms_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "terms",
+          "columnsFrom": [
+            "termId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "chats_userId_users_id_fk": {
+          "name": "chats_userId_users_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.definitionCoauthors": {
+      "name": "definitionCoauthors",
+      "schema": "",
+      "columns": {
+        "definitionId": {
+          "name": "definitionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "definitionCoauthors_definitionId_definitions_id_fk": {
+          "name": "definitionCoauthors_definitionId_definitions_id_fk",
+          "tableFrom": "definitionCoauthors",
+          "tableTo": "definitions",
+          "columnsFrom": [
+            "definitionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "definitionCoauthors_userId_users_id_fk": {
+          "name": "definitionCoauthors_userId_users_id_fk",
+          "tableFrom": "definitionCoauthors",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "definitionCoauthors_definitionId_userId_pk": {
+          "name": "definitionCoauthors_definitionId_userId_pk",
+          "columns": [
+            "definitionId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "comments_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "definitionId": {
+          "name": "definitionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revisionId": {
+          "name": "revisionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "migratedLegacy": {
+          "name": "migratedLegacy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "comments_definition_created_idx": {
+          "name": "comments_definition_created_idx",
+          "columns": [
+            {
+              "expression": "definitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comments_revision_idx": {
+          "name": "comments_revision_idx",
+          "columns": [
+            {
+              "expression": "revisionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comments_user_idx": {
+          "name": "comments_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comments_definitionId_definitions_id_fk": {
+          "name": "comments_definitionId_definitions_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "definitions",
+          "columnsFrom": [
+            "definitionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "comments_userId_users_id_fk": {
+          "name": "comments_userId_users_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "comments_revision_same_definition_fk": {
+          "name": "comments_revision_same_definition_fk",
+          "tableFrom": "comments",
+          "tableTo": "definitionRevisions",
+          "columnsFrom": [
+            "revisionId",
+            "definitionId"
+          ],
+          "columnsTo": [
+            "id",
+            "definitionId"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.definitionRevisions": {
+      "name": "definitionRevisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "definitionRevisions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "definitionId": {
+          "name": "definitionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previousRevisionId": {
+          "name": "previousRevisionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition": {
+          "name": "definition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "example": {
+          "name": "example",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "editorId": {
+          "name": "editorId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeNote": {
+          "name": "changeNote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacyIncomplete": {
+          "name": "legacyIncomplete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source": {
+          "name": "source",
+          "type": "definition_revision_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "derivedFromRevisionId": {
+          "name": "derivedFromRevisionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceRefinementId": {
+          "name": "sourceRefinementId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "definition_revisions_definition_version_unique": {
+          "name": "definition_revisions_definition_version_unique",
+          "columns": [
+            {
+              "expression": "definitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "definition_revisions_id_definition_unique": {
+          "name": "definition_revisions_id_definition_unique",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "definitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "definition_revisions_previous_unique": {
+          "name": "definition_revisions_previous_unique",
+          "columns": [
+            {
+              "expression": "previousRevisionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"definitionRevisions\".\"previousRevisionId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "definition_revisions_source_refinement_unique": {
+          "name": "definition_revisions_source_refinement_unique",
+          "columns": [
+            {
+              "expression": "sourceRefinementId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"definitionRevisions\".\"sourceRefinementId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "definition_revisions_editor_idx": {
+          "name": "definition_revisions_editor_idx",
+          "columns": [
+            {
+              "expression": "editorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "definition_revisions_derived_from_idx": {
+          "name": "definition_revisions_derived_from_idx",
+          "columns": [
+            {
+              "expression": "derivedFromRevisionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "definitionRevisions_definitionId_definitions_id_fk": {
+          "name": "definitionRevisions_definitionId_definitions_id_fk",
+          "tableFrom": "definitionRevisions",
+          "tableTo": "definitions",
+          "columnsFrom": [
+            "definitionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "definitionRevisions_editorId_users_id_fk": {
+          "name": "definitionRevisions_editorId_users_id_fk",
+          "tableFrom": "definitionRevisions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "editorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "definitionRevisions_sourceRefinementId_definitionRefinements_id_fk": {
+          "name": "definitionRevisions_sourceRefinementId_definitionRefinements_id_fk",
+          "tableFrom": "definitionRevisions",
+          "tableTo": "definitionRefinements",
+          "columnsFrom": [
+            "sourceRefinementId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "definition_revisions_previous_same_definition_fk": {
+          "name": "definition_revisions_previous_same_definition_fk",
+          "tableFrom": "definitionRevisions",
+          "tableTo": "definitionRevisions",
+          "columnsFrom": [
+            "previousRevisionId",
+            "definitionId"
+          ],
+          "columnsTo": [
+            "id",
+            "definitionId"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "definition_revisions_derived_from_fk": {
+          "name": "definition_revisions_derived_from_fk",
+          "tableFrom": "definitionRevisions",
+          "tableTo": "definitionRevisions",
+          "columnsFrom": [
+            "derivedFromRevisionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "definition_revisions_version_positive": {
+          "name": "definition_revisions_version_positive",
+          "value": "\"definitionRevisions\".\"version\" > 0"
+        },
+        "definition_revisions_predecessor_shape": {
+          "name": "definition_revisions_predecessor_shape",
+          "value": "(\"definitionRevisions\".\"version\" = 1 AND \"definitionRevisions\".\"previousRevisionId\" IS NULL)\n          OR (\"definitionRevisions\".\"version\" > 1 AND \"definitionRevisions\".\"previousRevisionId\" IS NOT NULL)"
+        },
+        "definition_revisions_nonblank_definition": {
+          "name": "definition_revisions_nonblank_definition",
+          "value": "btrim(\"definitionRevisions\".\"definition\") <> ''"
+        },
+        "definition_revisions_complete_or_legacy": {
+          "name": "definition_revisions_complete_or_legacy",
+          "value": "\"definitionRevisions\".\"legacyIncomplete\"\n          OR (\"definitionRevisions\".\"example\" IS NOT NULL\n              AND \"definitionRevisions\".\"editorId\" IS NOT NULL\n              AND \"definitionRevisions\".\"changeNote\" IS NOT NULL)"
+        },
+        "definition_revisions_nonblank_optional_text": {
+          "name": "definition_revisions_nonblank_optional_text",
+          "value": "(\"definitionRevisions\".\"example\" IS NULL OR btrim(\"definitionRevisions\".\"example\") <> '')\n          AND (\"definitionRevisions\".\"changeNote\" IS NULL OR btrim(\"definitionRevisions\".\"changeNote\") <> '')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.definitions": {
+      "name": "definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "definitions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "termId": {
+          "name": "termId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definitionNumber": {
+          "name": "definitionNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorId": {
+          "name": "authorId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition": {
+          "name": "definition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "example": {
+          "name": "example",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refinedFromId": {
+          "name": "refinedFromId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdVia": {
+          "name": "createdVia",
+          "type": "definition_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'classic'"
+        },
+        "currentRevisionId": {
+          "name": "currentRevisionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "definitions_author_idx": {
+          "name": "definitions_author_idx",
+          "columns": [
+            {
+              "expression": "authorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "definitions_author_term_original_unique": {
+          "name": "definitions_author_term_original_unique",
+          "columns": [
+            {
+              "expression": "authorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "termId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"definitions\".\"refinedFromId\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "definitions_current_revision_idx": {
+          "name": "definitions_current_revision_idx",
+          "columns": [
+            {
+              "expression": "currentRevisionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "definitions_term_number_unique": {
+          "name": "definitions_term_number_unique",
+          "columns": [
+            {
+              "expression": "termId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "definitionNumber",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "definitions_termId_terms_id_fk": {
+          "name": "definitions_termId_terms_id_fk",
+          "tableFrom": "definitions",
+          "tableTo": "terms",
+          "columnsFrom": [
+            "termId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "definitions_authorId_users_id_fk": {
+          "name": "definitions_authorId_users_id_fk",
+          "tableFrom": "definitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "authorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "definitions_refinedFromId_definitions_id_fk": {
+          "name": "definitions_refinedFromId_definitions_id_fk",
+          "tableFrom": "definitions",
+          "tableTo": "definitions",
+          "columnsFrom": [
+            "refinedFromId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "definitions_currentRevisionId_definitionRevisions_id_fk": {
+          "name": "definitions_currentRevisionId_definitionRevisions_id_fk",
+          "tableFrom": "definitions",
+          "tableTo": "definitionRevisions",
+          "columnsFrom": [
+            "currentRevisionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "definitions_definition_number_positive": {
+          "name": "definitions_definition_number_positive",
+          "value": "\"definitions\".\"definitionNumber\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.discussionSuggestions": {
+      "name": "discussionSuggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "discussionSuggestions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "definitionId": {
+          "name": "definitionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revisionId": {
+          "name": "revisionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestedDefinition": {
+          "name": "suggestedDefinition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestedExample": {
+          "name": "suggestedExample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outputDefinitionId": {
+          "name": "outputDefinitionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "discussion_suggestions_source_idx": {
+          "name": "discussion_suggestions_source_idx",
+          "columns": [
+            {
+              "expression": "definitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discussion_suggestions_user_idx": {
+          "name": "discussion_suggestions_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discussion_suggestions_output_unique": {
+          "name": "discussion_suggestions_output_unique",
+          "columns": [
+            {
+              "expression": "outputDefinitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"discussionSuggestions\".\"outputDefinitionId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discussionSuggestions_definitionId_definitions_id_fk": {
+          "name": "discussionSuggestions_definitionId_definitions_id_fk",
+          "tableFrom": "discussionSuggestions",
+          "tableTo": "definitions",
+          "columnsFrom": [
+            "definitionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "discussionSuggestions_userId_users_id_fk": {
+          "name": "discussionSuggestions_userId_users_id_fk",
+          "tableFrom": "discussionSuggestions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "discussionSuggestions_outputDefinitionId_definitions_id_fk": {
+          "name": "discussionSuggestions_outputDefinitionId_definitions_id_fk",
+          "tableFrom": "discussionSuggestions",
+          "tableTo": "definitions",
+          "columnsFrom": [
+            "outputDefinitionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "discussion_suggestions_revision_same_definition_fk": {
+          "name": "discussion_suggestions_revision_same_definition_fk",
+          "tableFrom": "discussionSuggestions",
+          "tableTo": "definitionRevisions",
+          "columnsFrom": [
+            "revisionId",
+            "definitionId"
+          ],
+          "columnsTo": [
+            "id",
+            "definitionId"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "discussion_suggestions_acceptance_pair": {
+          "name": "discussion_suggestions_acceptance_pair",
+          "value": "(\"discussionSuggestions\".\"acceptedAt\" IS NULL AND \"discussionSuggestions\".\"outputDefinitionId\" IS NULL)\n          OR (\"discussionSuggestions\".\"acceptedAt\" IS NOT NULL AND \"discussionSuggestions\".\"outputDefinitionId\" IS NOT NULL)"
+        },
+        "discussion_suggestions_nonblank_content": {
+          "name": "discussion_suggestions_nonblank_content",
+          "value": "btrim(\"discussionSuggestions\".\"comment\") <> ''\n          AND btrim(\"discussionSuggestions\".\"suggestedDefinition\") <> ''\n          AND btrim(\"discussionSuggestions\".\"suggestedExample\") <> ''\n          AND btrim(\"discussionSuggestions\".\"model\") <> ''\n          AND btrim(\"discussionSuggestions\".\"prompt\") <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.definitionEdits": {
+      "name": "definitionEdits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "definitionEdits_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "definitionId": {
+          "name": "definitionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "newDefinition": {
+          "name": "newDefinition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition": {
+          "name": "definition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "editedAt": {
+          "name": "editedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "definitionEdits_definitionId_definitions_id_fk": {
+          "name": "definitionEdits_definitionId_definitions_id_fk",
+          "tableFrom": "definitionEdits",
+          "tableTo": "definitions",
+          "columnsFrom": [
+            "definitionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.emailAuthTokens": {
+      "name": "emailAuthTokens",
+      "schema": "",
+      "columns": {
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(254)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowAccountCreation": {
+          "name": "allowAccountCreation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usedAt": {
+          "name": "usedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_auth_tokens_email_created_idx": {
+          "name": "email_auth_tokens_email_created_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_auth_tokens_expires_idx": {
+          "name": "email_auth_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauthAccounts": {
+      "name": "oauthAccounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "oauthAccounts_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessTokenEncrypted": {
+          "name": "accessTokenEncrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshTokenEncrypted": {
+          "name": "refreshTokenEncrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_accounts_provider_subject_unique": {
+          "name": "oauth_accounts_provider_subject_unique",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_accounts_user_provider_unique": {
+          "name": "oauth_accounts_user_provider_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_accounts_user_idx": {
+          "name": "oauth_accounts_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauthAccounts_userId_users_id_fk": {
+          "name": "oauthAccounts_userId_users_id_fk",
+          "tableFrom": "oauthAccounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.definitionRefinements": {
+      "name": "definitionRefinements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "definitionRefinements_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "definitionId": {
+          "name": "definitionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceRevisionId": {
+          "name": "sourceRevisionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userComment": {
+          "name": "userComment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggestedDefinition": {
+          "name": "suggestedDefinition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggestedExample": {
+          "name": "suggestedExample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promptKey": {
+          "name": "promptKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promptHash": {
+          "name": "promptHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promptText": {
+          "name": "promptText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "refinement_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "suggestedAt": {
+          "name": "suggestedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decidedAt": {
+          "name": "decidedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "definition_refinements_definition_round_unique": {
+          "name": "definition_refinements_definition_round_unique",
+          "columns": [
+            {
+              "expression": "definitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "round",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "definition_refinements_source_revision_idx": {
+          "name": "definition_refinements_source_revision_idx",
+          "columns": [
+            {
+              "expression": "sourceRevisionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "definitionRefinements_definitionId_definitions_id_fk": {
+          "name": "definitionRefinements_definitionId_definitions_id_fk",
+          "tableFrom": "definitionRefinements",
+          "tableTo": "definitions",
+          "columnsFrom": [
+            "definitionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "definition_refinements_source_same_definition_fk": {
+          "name": "definition_refinements_source_same_definition_fk",
+          "tableFrom": "definitionRefinements",
+          "tableTo": "definitionRevisions",
+          "columnsFrom": [
+            "sourceRevisionId",
+            "definitionId"
+          ],
+          "columnsTo": [
+            "id",
+            "definitionId"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.siteFeedback": {
+      "name": "siteFeedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "siteFeedback_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pagePath": {
+          "name": "pagePath",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "feedback_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolvedAt": {
+          "name": "resolvedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolvedByUserId": {
+          "name": "resolvedByUserId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "site_feedback_status_id_idx": {
+          "name": "site_feedback_status_id_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "site_feedback_user_idx": {
+          "name": "site_feedback_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "site_feedback_resolved_by_user_idx": {
+          "name": "site_feedback_resolved_by_user_idx",
+          "columns": [
+            {
+              "expression": "resolvedByUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "siteFeedback_userId_users_id_fk": {
+          "name": "siteFeedback_userId_users_id_fk",
+          "tableFrom": "siteFeedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "siteFeedback_resolvedByUserId_users_id_fk": {
+          "name": "siteFeedback_resolvedByUserId_users_id_fk",
+          "tableFrom": "siteFeedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolvedByUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "site_feedback_page_path_shape": {
+          "name": "site_feedback_page_path_shape",
+          "value": "char_length(\"siteFeedback\".\"pagePath\") > 0\n          AND left(\"siteFeedback\".\"pagePath\", 1) = '/'\n          AND left(\"siteFeedback\".\"pagePath\", 2) <> '//'\n          AND position(chr(92) in \"siteFeedback\".\"pagePath\") = 0\n          AND position('?' in \"siteFeedback\".\"pagePath\") = 0\n          AND position('#' in \"siteFeedback\".\"pagePath\") = 0\n          AND \"siteFeedback\".\"pagePath\" !~ '[[:cntrl:]]'"
+        },
+        "site_feedback_message_content": {
+          "name": "site_feedback_message_content",
+          "value": "btrim(\"siteFeedback\".\"message\") <> ''\n          AND char_length(\"siteFeedback\".\"message\") <= 2000"
+        },
+        "site_feedback_resolution_shape": {
+          "name": "site_feedback_resolution_shape",
+          "value": "(\"siteFeedback\".\"status\" = 'open'\n            AND \"siteFeedback\".\"resolvedAt\" IS NULL\n            AND \"siteFeedback\".\"resolvedByUserId\" IS NULL)\n          OR (\"siteFeedback\".\"status\" = 'resolved'\n            AND \"siteFeedback\".\"resolvedAt\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "tags_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheme": {
+          "name": "scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mappingIri": {
+          "name": "mappingIri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mappingRelation": {
+          "name": "mappingRelation",
+          "type": "skos_match",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tagsToTerms": {
+      "name": "tagsToTerms",
+      "schema": "",
+      "columns": {
+        "definitionId": {
+          "name": "definitionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagId": {
+          "name": "tagId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tagsToTerms_definitionId_definitions_id_fk": {
+          "name": "tagsToTerms_definitionId_definitions_id_fk",
+          "tableFrom": "tagsToTerms",
+          "tableTo": "definitions",
+          "columnsFrom": [
+            "definitionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tagsToTerms_tagId_tags_id_fk": {
+          "name": "tagsToTerms_tagId_tags_id_fk",
+          "tableFrom": "tagsToTerms",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tagId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tagsToTerms_tagId_definitionId_pk": {
+          "name": "tagsToTerms_tagId_definitionId_pk",
+          "columns": [
+            "tagId",
+            "definitionId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.terms": {
+      "name": "terms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "terms_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "term": {
+          "name": "term",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nextDefinitionNumber": {
+          "name": "nextDefinitionNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "terms_term_unique": {
+          "name": "terms_term_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "term"
+          ]
+        },
+        "terms_slug_unique": {
+          "name": "terms_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "terms_next_definition_number_positive": {
+          "name": "terms_next_definition_number_positive",
+          "value": "\"terms\".\"nextDefinitionNumber\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "users_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "googleId": {
+          "name": "googleId",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orcidId": {
+          "name": "orcidId",
+          "type": "varchar(19)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firstName": {
+          "name": "firstName",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastName": {
+          "name": "lastName",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affiliation": {
+          "name": "affiliation",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(254)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerifiedAt": {
+          "name": "emailVerifiedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isAi": {
+          "name": "isAi",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isProfilePublic": {
+          "name": "isProfilePublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "notifications": {
+          "name": "notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "users_human_email_normalized_unique": {
+          "name": "users_human_email_normalized_unique",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"users\".\"email\" IS NOT NULL AND NOT \"users\".\"isAi\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_googleId_unique": {
+          "name": "users_googleId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "googleId"
+          ]
+        },
+        "users_orcidId_unique": {
+          "name": "users_orcidId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "orcidId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "revisionId": {
+          "name": "revisionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definitionId": {
+          "name": "definitionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "vote_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "migratedLegacy": {
+          "name": "migratedLegacy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "votes_definition_revision_idx": {
+          "name": "votes_definition_revision_idx",
+          "columns": [
+            {
+              "expression": "definitionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revisionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "votes_user_idx": {
+          "name": "votes_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "votes_definitionId_definitions_id_fk": {
+          "name": "votes_definitionId_definitions_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "definitions",
+          "columnsFrom": [
+            "definitionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "votes_userId_users_id_fk": {
+          "name": "votes_userId_users_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "votes_revision_same_definition_fk": {
+          "name": "votes_revision_same_definition_fk",
+          "tableFrom": "votes",
+          "tableTo": "definitionRevisions",
+          "columnsFrom": [
+            "revisionId",
+            "definitionId"
+          ],
+          "columnsTo": [
+            "id",
+            "definitionId"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "votes_revisionId_userId_pk": {
+          "name": "votes_revisionId_userId_pk",
+          "columns": [
+            "revisionId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.chat_type": {
+      "name": "chat_type",
+      "schema": "public",
+      "values": [
+        "system",
+        "user"
+      ]
+    },
+    "public.definition_revision_source": {
+      "name": "definition_revision_source",
+      "schema": "public",
+      "values": [
+        "initial",
+        "author_edit",
+        "ai_refinement",
+        "ai_generation",
+        "rollback",
+        "legacy"
+      ]
+    },
+    "public.definition_source": {
+      "name": "definition_source",
+      "schema": "public",
+      "values": [
+        "classic",
+        "interactive"
+      ]
+    },
+    "public.feedback_status": {
+      "name": "feedback_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "resolved"
+      ]
+    },
+    "public.refinement_status": {
+      "name": "refinement_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "suggested",
+        "accepted",
+        "kept",
+        "superseded",
+        "failed"
+      ]
+    },
+    "public.skos_match": {
+      "name": "skos_match",
+      "schema": "public",
+      "values": [
+        "exactMatch",
+        "closeMatch",
+        "broadMatch",
+        "narrowMatch",
+        "relatedMatch"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "moderator",
+        "admin"
+      ]
+    },
+    "public.vote_type": {
+      "name": "vote_type",
+      "schema": "public",
+      "values": [
+        "up",
+        "down"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1784931412107,
       "tag": "0026_amused_xorn",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1785413425143,
+      "tag": "0027_hard_killraven",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -98,6 +98,9 @@ export const emailAuthTokensTable = pgTable(
     // message delivered to the requested mailbox.
     tokenHash: varchar({ length: 64 }).primaryKey(),
     email: varchar({ length: 254 }).notNull(),
+    // A token requested through the explicit registration page may create a
+    // human account. Ordinary sign-in tokens may only claim an existing one.
+    allowAccountCreation: boolean().notNull().default(false),
     expiresAt: timestamp({ mode: "string" }).notNull(),
     usedAt: timestamp({ mode: "string" }),
     createdAt: timestamp({ mode: "string" }).defaultNow().notNull()

--- a/lib/email-auth-intent.ts
+++ b/lib/email-auth-intent.ts
@@ -1,0 +1,3 @@
+import { z } from "zod"
+
+export const EmailAuthIntentSchema = z.enum(["sign-in", "create"])

--- a/lib/email-auth.ts
+++ b/lib/email-auth.ts
@@ -6,6 +6,7 @@ import {
   hashOneTimeToken,
   oneTimeTokenExpiry
 } from "@/lib/auth-tokens"
+export { EmailAuthIntentSchema } from "@/lib/email-auth-intent"
 
 export const EmailAddressSchema = z
   .string()
@@ -16,6 +17,10 @@ export const EmailAddressSchema = z
 
 export const isEmailAuthEnabled = () =>
   process.env.EMAIL_AUTH_ENABLED === "true"
+
+export const isEmailAccountCreationEnabled = () =>
+  isEmailAuthEnabled() &&
+  process.env.EMAIL_AUTH_ACCOUNT_CREATION_ENABLED === "true"
 
 export const getAuthSiteUrl = () => {
   const raw = process.env.NEXT_PUBLIC_SITE_URL?.trim()

--- a/scripts/test-auth-plumbing.ts
+++ b/scripts/test-auth-plumbing.ts
@@ -7,6 +7,7 @@ import {
   hashOneTimeToken,
   oneTimeTokenExpiry
 } from "../lib/auth-tokens"
+import { EmailAuthIntentSchema } from "../lib/email-auth-intent"
 import {
   DEFINITION_MAX_LENGTH,
   EXAMPLE_MAX_LENGTH,
@@ -62,6 +63,31 @@ assert.notEqual(hashOneTimeToken(firstToken), hashOneTimeToken(secondToken))
 assert.equal(
   oneTimeTokenExpiry({ lifetimeMinutes: 15, now: 0 }),
   "1970-01-01T00:15:00.000Z"
+)
+assert.equal(EmailAuthIntentSchema.safeParse("sign-in").success, true)
+assert.equal(EmailAuthIntentSchema.safeParse("create").success, true)
+assert.equal(EmailAuthIntentSchema.safeParse("register").success, false)
+
+const loginPage = readFileSync(resolve("app/login/page.tsx"), "utf8")
+const registrationPage = readFileSync(resolve("app/register/page.tsx"), "utf8")
+const emailStartRoute = readFileSync(
+  resolve("app/api/auth/email/start/route.ts"),
+  "utf8"
+)
+const emailVerifyRoute = readFileSync(
+  resolve("app/api/auth/email/verify/route.ts"),
+  "utf8"
+)
+assert.match(loginPage, /name="intent" value="sign-in"/)
+assert.match(registrationPage, /name="intent" value="create"/)
+assert.match(registrationPage, /isEmailAccountCreationEnabled\(\)/)
+assert.match(
+  emailStartRoute,
+  /if \(!allowAccountCreation\)[\s\S]*usersTable\.email[\s\S]*if \(!existingUser\) return false/
+)
+assert.match(
+  emailVerifyRoute,
+  /else if \(claimed\.allowAccountCreation\)[\s\S]*insert\(usersTable\)/
 )
 
 const validTerm = {

--- a/scripts/test-deployment-contract.ts
+++ b/scripts/test-deployment-contract.ts
@@ -63,10 +63,12 @@ const expectedOperationsOnlyPaths = [
   "README.md",
   "developing.md",
   "deploy/README.md",
+  "deploy/configure-email-auth.sh",
   "deploy/cutover-ego-public.sh",
   "deploy/deploy-ego-from-workstation.sh",
   "deploy/ego/AGENTS.md",
   "deploy/lib/cutover-ego-public-remote.sh",
+  "deploy/lib/configure-email-auth-remote.sh",
   "deploy/lib/deploy-ego-precutover-remote.sh",
   "deploy/lib/export-superego-for-ego-seed-remote.sh",
   "deploy/lib/seed-ego-from-superego-remote.sh",
@@ -498,6 +500,16 @@ for (const [environment, values] of [
     "MatSci-SAM",
     `${environment} must use the protected MatSci-SAM application identity`
   )
+  assert.equal(
+    values.get("EMAIL_AUTH_ENABLED"),
+    "false",
+    `${environment} must default email authentication off`
+  )
+  assert.equal(
+    values.get("EMAIL_AUTH_ACCOUNT_CREATION_ENABLED"),
+    "false",
+    `${environment} must default email account creation off`
+  )
 }
 assert.equal(ego.get("SESSION_COOKIE_SECURE"), "true")
 assert.equal(ego.get("DEV_AUTH_ENABLED"), "false")
@@ -613,6 +625,49 @@ assert.match(
   /"\$\{source_verifier\}" --create-archive "\$\{repo\}" "\$\{candidate\}" "\$\{archive\}"/
 )
 assert.doesNotMatch(repeatableRelease, /^\s*git(?:\s+-C "[^"]+")?\s+archive\b/m)
+
+const emailAuthConfigurator = read("deploy/configure-email-auth.sh")
+const emailAuthConfiguratorRemote = read(
+  "deploy/lib/configure-email-auth-remote.sh"
+)
+assert.match(
+  emailAuthConfigurator,
+  /<superego\|ego> <stage\|enable\|disable>/
+)
+assert.match(
+  emailAuthConfigurator,
+  /status --porcelain=v1[\s\S]*checkout must equal the reviewed origin\/dev commit/
+)
+assert.match(
+  emailAuthConfigurator,
+  /EMAIL_AUTH_GMAIL_REFRESH_TOKEN: tokenDocument\.refresh_token/
+)
+assert.match(
+  emailAuthConfigurator,
+  /base64 --decode[\s\S]*sudo \/bin\/bash -s --/
+)
+assert.doesNotMatch(emailAuthConfigurator, /systemctl|journalctl/)
+assert.match(
+  emailAuthConfiguratorRemote,
+  /expected_hostname=cci-superego[\s\S]*expected_hostname=cci-ego/
+)
+assert.match(
+  emailAuthConfiguratorRemote,
+  /sha256sum "\$\{payload\}"[\s\S]*expected_payload_sha/
+)
+assert.match(
+  emailAuthConfiguratorRemote,
+  /app\.env\.\$\(date -u[\s\S]*install -o root -g root -m 0400/
+)
+assert.match(
+  emailAuthConfiguratorRemote,
+  /chown root:matsci-sam "\$\{partial\}"[\s\S]*chmod 0640 "\$\{partial\}"[\s\S]*mv -f "\$\{partial\}" "\$\{config\}"/
+)
+assert.match(
+  emailAuthConfiguratorRemote,
+  /No secret values were displayed and no service was restarted/
+)
+assert.doesNotMatch(emailAuthConfiguratorRemote, /systemctl|journalctl/)
 
 const releaseForwardAncestryIndex = repeatableRelease.search(
   /git -C "\$\{repo\}" merge-base --is-ancestor "\$\{active_commit\}" "\$\{candidate\}"/
@@ -1631,6 +1686,7 @@ try {
     "AUTH_TOKEN_ENCRYPTION_KEY=missing",
     "DATABASE_URL=blank",
     "DEV_AUTH_ENABLED=missing",
+    "EMAIL_AUTH_ACCOUNT_CREATION_ENABLED=missing",
     "EMAIL_AUTH_ENABLED=missing",
     "GOOGLE_AUTH_ACCESS_MODE=missing",
     "GOOGLE_AUTH_ALLOWED_EMAILS=missing",


### PR DESCRIPTION
## What changed

- separates passwordless sign-in from explicit new-account creation
- makes ordinary email sign-in issue links only for existing human accounts
- adds an account-creation grant to one-time tokens and migration 0027
- warns retained Ego contributors to use their existing Google identity first
- adds independent feature flags for email sign-in and account creation
- adds a supervised, secret-safe Gmail configuration wrapper for Superego and Ego

## Why

Ego's privacy-filtered seed retained Google subjects but erased contributor
email addresses. The previous combined email flow could create a second account
when an imported contributor entered an address before signing in with Google.
This change prevents the ordinary login route from silently creating an account
and makes registration an explicit choice.

## Operations

The local Gmail sender refresh token was validated with the send-only scope,
and Gmail accepted a token-free delivery test from
`matsci-sam@systemada.com`. The new wrapper stages credentials with both flags
off, never prints secret values, requires supervised remote sudo, creates a
root-only configuration backup, and does not restart services.

## Validation

- `pnpm lint` (two pre-existing React Compiler compatibility warnings)
- `pnpm check-types`
- `pnpm build`
- `pnpm test:auth`
- `pnpm test:deployment`
- `pnpm test:interface`
- `pnpm test:identifiers`
- `pnpm test:ollama-context`
- local production smoke test for `/login`, `/register`, legacy-account warning,
  and zero tokens for unknown ordinary sign-in
- migration 0027 applied successfully to the local development database
