### PR TITLE
Tighten conference home layout

### DIFF
--- a/app/home.module.css
+++ b/app/home.module.css
@@ -11,9 +11,9 @@
 .hero {
   display: grid;
   grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.05fr);
-  gap: 2rem;
+  gap: 1.5rem;
   align-items: start;
-  padding: 1.25rem 0 3rem;
+  padding: 0.85rem 0 2rem;
 }
 
 .heroIntroduction {
@@ -67,7 +67,7 @@
 
 .contributionPanel {
   scroll-margin-top: 1rem;
-  margin-top: 1.5rem;
+  margin-top: 1rem;
   padding: 1.1rem;
   border: 1px solid var(--border);
   border-radius: var(--radius-xl);
@@ -501,8 +501,8 @@
 }
 
 .communitySection {
-  margin-top: 3.5rem;
-  padding-top: 3rem;
+  margin-top: 2rem;
+  padding-top: 2rem;
 }
 
 .activityColumns {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -74,8 +74,8 @@ export default async function Home() {
             aria-labelledby="conference-guide-heading"
           >
             <h2 id="conference-guide-heading">
-              Here for the 2026 NSF HDR Ecosystem Conference? Explore{" "}
-              {SITE_NAME} in 90 seconds
+              Here for the HDR Ecosystem Conference? Explore {SITE_NAME} in 90
+              seconds
             </h2>
             <ol>
               <li>


### PR DESCRIPTION
## What changed

- updates the conference banner to read “Here for the HDR Ecosystem Conference? Explore MatSci-SAM in 90 seconds”
- reduces vertical spacing between the conference guide, hero cards, contribution card, and community section
- preserves the existing page width, horizontal gutters, and banner-internal padding

## Why

The home page used too much vertical space between cards, limiting how much content visitors could see on initial load. The banner copy also needed to stay current for the broader HDR Ecosystem Conference audience.

## Impact

Visitors see more of the home-page content without changing the card content or the overall horizontal layout.

## Validation

- reviewed interactively at `http://localhost:3000`
- `pnpm exec prettier --check app/page.tsx app/home.module.css`
- `pnpm test:interface`
- `pnpm check-types`
- `pnpm lint`
